### PR TITLE
Fix handling of protected objects

### DIFF
--- a/ClasslessObjects/ClasslessObjects.m
+++ b/ClasslessObjects/ClasslessObjects.m
@@ -311,8 +311,13 @@ SetAttributes[setMember, HoldRest]
 
 setMember[obj_?ObjectQ, lhs_, rhs_] :=
 	WithOrdinaryObjectSet[obj,
-		(* Definition that makes member inheritable. *)
-		obj[lhs, _] = rhs;
+		(* Don't duplicate Set::write warning if object is protected. *)
+		Quiet[
+			(* Definition that makes member inheritable. *)
+			obj[lhs, _] = rhs
+			,
+			Set::write
+		];
 		
 		(* Ordinary definition. *)
 		obj[lhs] = rhs
@@ -328,8 +333,13 @@ SetAttributes[bindMember, HoldRest]
 
 bindMember[obj_?ObjectQ, lhs_, rhs_] :=
 	WithOrdinaryObjectSet[obj,
-		(* Inheritable definition providing $self variable. *)
-		obj[lhs, self_] := Block[{$self = self}, rhs];
+		(* Don't duplicate SetDelayed::write warning if object is protected. *)
+		Quiet[
+			(* Inheritable definition providing $self variable. *)
+			obj[lhs, self_] := Block[{$self = self}, rhs]
+			,
+			SetDelayed::write
+		];
 		
 		(* Ordinary definition providing $self variable. *)
 		obj[lhs] := Block[{$self = obj}, rhs]

--- a/ClasslessObjects/ClasslessObjects.m
+++ b/ClasslessObjects/ClasslessObjects.m
@@ -228,9 +228,11 @@ WithOrdinaryObjectSet[obj_?ObjectQ, body_] :=
 	Module[
 		{
 			upValues = UpValues[obj],
+			protected,
 			result
 		}
 		,
+		protected = Unprotect[obj];
 		(*
 			All "set altering" definitions are attached to objects via
 			UpValues, remove them temporarily.
@@ -240,10 +242,13 @@ WithOrdinaryObjectSet[obj_?ObjectQ, body_] :=
 				UpValues[obj],
 				Except[HoldPattern[HoldPattern][_Set | _SetDelayed | _Unset]]
 			];
+		Protect @@ protected;
 		
 		result = body;
 		
+		Unprotect @@ protected;
 		UpValues[obj] = upValues;
+		Protect @@ protected;
 		
 		result
 	]

--- a/ClasslessObjects/Tests/Integration/ProtectedObjects.mt
+++ b/ClasslessObjects/Tests/Integration/ProtectedObjects.mt
@@ -1,0 +1,212 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage["ClasslessObjects`Tests`Acceptance`ProtectedObjects`", {"MUnit`"}]
+
+
+Get["ClasslessObjects`"]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+(* ::Subsection:: *)
+(*Set*)
+
+
+Module[
+	{obj, member, value}
+	,
+	DeclareObject[obj];
+	Protect[obj];
+	
+	Test[
+		WithOrdinaryObjectSet[obj,
+			obj@member = value
+		]
+		,
+		value
+		,
+		Message[Set::write, obj, obj@member]
+		,
+		TestID -> "Set: non-inheritable member"
+	]
+]
+
+
+Module[
+	{obj, member, value}
+	,
+	DeclareObject[obj];
+	Protect[obj];
+	
+	Test[
+		WithOrdinaryObjectSet[obj,
+			obj[member, _] = value
+		]
+		,
+		value
+		,
+		Message[Set::write, obj, obj[member, _]]
+		,
+		TestID -> "Set: inheritable-only member"
+	]
+]
+
+
+Module[
+	{obj, member, value}
+	,
+	DeclareObject[obj];
+	Protect[obj];
+	
+	Test[
+		obj@member = value
+		,
+		value
+		,
+		Message[Set::write, obj, obj@member]
+		,
+		TestID -> "Set: inheritable member"
+	]
+]
+
+
+(* ::Subsection:: *)
+(*SetDelayed*)
+
+
+Module[
+	{obj, member, value}
+	,
+	DeclareObject[obj];
+	Protect[obj];
+	
+	Test[
+		WithOrdinaryObjectSet[obj,
+			obj@member := value
+		]
+		,
+		$Failed
+		,
+		Message[SetDelayed::write, obj, obj@member]
+		,
+		TestID -> "SetDelayed: non-inheritable member"
+	]
+]
+
+
+Module[
+	{obj, member, value}
+	,
+	DeclareObject[obj];
+	Protect[obj];
+	
+	Test[
+		WithOrdinaryObjectSet[obj,
+			obj[member, _] := value
+		]
+		,
+		$Failed
+		,
+		Message[SetDelayed::write, obj, obj[member, _]]
+		,
+		TestID -> "SetDelayed: inheritable-only member"
+	]
+]
+
+
+Module[
+	{obj, member, value}
+	,
+	DeclareObject[obj];
+	Protect[obj];
+	
+	Test[
+		obj@member := value
+		,
+		$Failed
+		,
+		Message[SetDelayed::write, obj, obj@member]
+		,
+		TestID -> "SetDelayed: inheritable member"
+	]
+]
+
+
+(* ::Subsection:: *)
+(*Unset*)
+
+
+Module[
+	{obj, member}
+	,
+	DeclareObject[obj];
+	Protect[obj];
+	
+	Test[
+		WithOrdinaryObjectSet[obj,
+			obj@member =.
+		]
+		,
+		$Failed
+		,
+		Message[Unset::write, obj, obj@member]
+		,
+		TestID -> "Unset: non-inheritable member"
+	]
+]
+
+
+Module[
+	{obj, member}
+	,
+	DeclareObject[obj];
+	Protect[obj];
+	
+	Test[
+		WithOrdinaryObjectSet[obj,
+			obj[member, _] =.
+		]
+		,
+		$Failed
+		,
+		Message[Unset::write, obj, obj[member, _]]
+		,
+		TestID -> "Unset: inheritable-only member"
+	]
+]
+
+
+Module[
+	{obj, member}
+	,
+	DeclareObject[obj];
+	Protect[obj];
+	
+	Test[
+		obj@member =.
+		,
+		$Failed
+		,
+		Message[Unset::write, obj, obj@member]
+		,
+		TestID -> "Unset: inheritable member"
+	]
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/ClasslessObjects/Tests/Integration/suite.mt
+++ b/ClasslessObjects/Tests/Integration/suite.mt
@@ -4,5 +4,6 @@ TestSuite[{
 	"MembersNoInheritance.mt",
 	"MembersOneLevelInheritance.mt",
 	"MembersTwoLevelInheritance.mt",
-	"MembersExplicitSelf.mt"
+	"MembersExplicitSelf.mt",
+	"ProtectedObjects.mt"
 }]

--- a/ClasslessObjects/Tests/Unit/bindMember.mt
+++ b/ClasslessObjects/Tests/Unit/bindMember.mt
@@ -18,6 +18,10 @@ AppendTo[$ContextPath, "ClasslessObjects`Private`"]
 
 
 (* ::Subsection:: *)
+(*Non-protected object*)
+
+
+(* ::Subsubsection:: *)
 (*Set member*)
 
 
@@ -47,7 +51,7 @@ Module[
 ]
 
 
-(* ::Subsection:: *)
+(* ::Subsubsection:: *)
 (*Reset member*)
 
 
@@ -71,6 +75,74 @@ Module[
 		{
 			HoldPattern[obj[member]] :>  Block[{$self = obj}, newValue],
 			HoldPattern[obj[member, self_]] :> Block[{$self = self}, newValue]
+		}
+		,
+		TestID -> "Reset member: object down values"
+	];
+]
+
+
+(* ::Subsection:: *)
+(*Protected object*)
+
+
+(* ::Subsubsection:: *)
+(*Set member*)
+
+
+Module[
+	{obj, member, value}
+	,
+	ObjectQ[obj] ^= True;
+	Protect[obj];
+	
+	Test[
+		bindMember[obj, member, value]
+		,
+		$Failed
+		,
+		Message[SetDelayed::write, obj, obj@member]
+		,
+		TestID -> "Set member: bindMember evaluation"
+	];
+	
+	Test[
+		DownValues[obj]
+		,
+		{}
+		,
+		TestID -> "Set member: object down values"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*Reset member*)
+
+
+Module[
+	{obj, member, oldValue, newValue}
+	,
+	ObjectQ[obj] ^= True;
+	bindMember[obj, member, oldValue];
+	Protect[obj];
+	
+	Test[
+		bindMember[obj, member, newValue]
+		,
+		$Failed
+		,
+		Message[SetDelayed::write, obj, obj@member]
+		,
+		TestID -> "Reset member: bindMember evaluation"
+	];
+	
+	Test[
+		DownValues[obj]
+		,
+		{
+			HoldPattern[obj[member]] :>  Block[{$self = obj}, oldValue],
+			HoldPattern[obj[member, self_]] :> Block[{$self = self}, oldValue]
 		}
 		,
 		TestID -> "Reset member: object down values"

--- a/ClasslessObjects/Tests/Unit/setMember.mt
+++ b/ClasslessObjects/Tests/Unit/setMember.mt
@@ -18,6 +18,10 @@ AppendTo[$ContextPath, "ClasslessObjects`Private`"]
 
 
 (* ::Subsection:: *)
+(*Non-protected object*)
+
+
+(* ::Subsubsection:: *)
 (*Set member*)
 
 
@@ -47,7 +51,7 @@ Module[
 ]
 
 
-(* ::Subsection:: *)
+(* ::Subsubsection:: *)
 (*Reset member*)
 
 
@@ -74,6 +78,74 @@ Module[
 		}
 		,
 		TestID -> "Reset member: object down values"
+	];
+]
+
+
+(* ::Subsection:: *)
+(*Protected object*)
+
+
+(* ::Subsubsection:: *)
+(*Set member*)
+
+
+Module[
+	{obj, member, value}
+	,
+	ObjectQ[obj] ^= True;
+	Protect[obj];
+	
+	Test[
+		setMember[obj, member, value]
+		,
+		value
+		,
+		Message[Set::write, obj, obj@member]
+		,
+		TestID -> "Protected: Set member: setMember evaluation"
+	];
+	
+	Test[
+		DownValues[obj]
+		,
+		{}
+		,
+		TestID -> "Protected: Set member: object down values"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*Reset member*)
+
+
+Module[
+	{obj, member, oldValue, newValue}
+	,
+	ObjectQ[obj] ^= True;
+	setMember[obj, member, oldValue];
+	Protect[obj];
+	
+	Test[
+		setMember[obj, member, newValue]
+		,
+		newValue
+		,
+		Message[Set::write, obj, obj@member]
+		,
+		TestID -> "Protected: Reset member: setMember evaluation"
+	];
+	
+	Test[
+		DownValues[obj]
+		,
+		{
+			HoldPattern[obj[member]] :> oldValue,
+			HoldPattern[obj[member, _]] :> oldValue
+		}
+		,
+		TestID -> "Protected: Reset member: object down values"
 	];
 ]
 

--- a/ClasslessObjects/Tests/Unit/unsetMember.mt
+++ b/ClasslessObjects/Tests/Unit/unsetMember.mt
@@ -18,6 +18,10 @@ AppendTo[$ContextPath, "ClasslessObjects`Private`"]
 
 
 (* ::Subsection:: *)
+(*Non-protected object*)
+
+
+(* ::Subsubsection:: *)
 (*Unset non-existing member*)
 
 
@@ -46,7 +50,7 @@ Module[
 ]
 
 
-(* ::Subsection:: *)
+(* ::Subsubsection:: *)
 (*Unset non-inheritable member*)
 
 
@@ -74,7 +78,7 @@ Module[
 ]
 
 
-(* ::Subsection:: *)
+(* ::Subsubsection:: *)
 (*Unset non-inheritable delayed member*)
 
 
@@ -102,7 +106,7 @@ Module[
 ]
 
 
-(* ::Subsection:: *)
+(* ::Subsubsection:: *)
 (*Unset inheritable-only member*)
 
 
@@ -130,7 +134,7 @@ Module[
 ]
 
 
-(* ::Subsection:: *)
+(* ::Subsubsection:: *)
 (*Unset inheritable-only delayed member*)
 
 
@@ -158,7 +162,7 @@ Module[
 ]
 
 
-(* ::Subsection:: *)
+(* ::Subsubsection:: *)
 (*Unset inheritable member*)
 
 
@@ -187,7 +191,7 @@ Module[
 ]
 
 
-(* ::Subsection:: *)
+(* ::Subsubsection:: *)
 (*Unset inheritable delayed member*)
 
 
@@ -212,6 +216,239 @@ Module[
 		{}
 		,
 		TestID -> "inheritable-only member: object down values"
+	];
+]
+
+
+(* ::Subsection:: *)
+(*Protected object*)
+
+
+(* ::Subsubsection:: *)
+(*Unset non-existing member*)
+
+
+Module[
+	{obj, member, downValues}
+	,
+	ObjectQ[obj] ^= True;
+	Protect[obj];
+	downValues = DownValues[obj];
+	
+	Test[
+		unsetMember[obj, member]
+		,
+		$Failed
+		,
+		Message[Unset::write, obj, obj@member]
+		,
+		TestID -> "protected: non-existing member: unsetMember evaluation"
+	];
+	
+	Test[
+		DownValues[obj]
+		,
+		downValues
+		,
+		TestID -> "protected: non-existing member: object down values"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*Unset non-inheritable member*)
+
+
+Module[
+	{obj, member, value, downValues}
+	,
+	ObjectQ[obj] ^= True;
+	obj@member = value;
+	Protect[obj];
+	downValues = DownValues[obj];
+	
+	Test[
+		unsetMember[obj, member]
+		,
+		$Failed
+		,
+		Message[Unset::write, obj, obj@member]
+		,
+		TestID -> "protected: non-inheritable member: unsetMember evaluation"
+	];
+	
+	Test[
+		DownValues[obj]
+		,
+		downValues
+		,
+		TestID -> "protected: non-inheritable member: object down values"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*Unset non-inheritable delayed member*)
+
+
+Module[
+	{obj, member, value, downValues}
+	,
+	ObjectQ[obj] ^= True;
+	obj@member := value;
+	Protect[obj];
+	downValues = DownValues[obj];
+	
+	Test[
+		unsetMember[obj, member]
+		,
+		$Failed
+		,
+		Message[Unset::write, obj, obj@member]
+		,
+		TestID ->
+			"protected: non-inheritable delayed member: unsetMember evaluation"
+	];
+	
+	Test[
+		DownValues[obj]
+		,
+		downValues
+		,
+		TestID ->
+			"protected: non-inheritable delayed member: object down values"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*Unset inheritable-only member*)
+
+
+Module[
+	{obj, member, value, downValues}
+	,
+	ObjectQ[obj] ^= True;
+	obj[member, _] = value;
+	Protect[obj];
+	downValues = DownValues[obj];
+	
+	Test[
+		unsetMember[obj, member]
+		,
+		$Failed
+		,
+		Message[Unset::write, obj, obj@member]
+		,
+		TestID -> "protected: inheritable-only member: unsetMember evaluation"
+	];
+	
+	Test[
+		DownValues[obj]
+		,
+		downValues
+		,
+		TestID -> "protected: inheritable-only member: object down values"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*Unset inheritable-only delayed member*)
+
+
+Module[
+	{obj, member, value, downValues}
+	,
+	ObjectQ[obj] ^= True;
+	obj[member, self_] := self + value;
+	Protect[obj];
+	downValues = DownValues[obj];
+	
+	Test[
+		unsetMember[obj, member]
+		,
+		$Failed
+		,
+		Message[Unset::write, obj, obj@member]
+		,
+		TestID -> "protected: inheritable-only delayed member: \
+unsetMember evaluation"
+	];
+	
+	Test[
+		DownValues[obj]
+		,
+		downValues
+		,
+		TestID ->
+			"protected: inheritable-only delayed member: object down values"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*Unset inheritable member*)
+
+
+Module[
+	{obj, member, value, downValues}
+	,
+	ObjectQ[obj] ^= True;
+	obj[member] = value;
+	obj[member, _] = value;
+	Protect[obj];
+	downValues = DownValues[obj];
+	
+	Test[
+		unsetMember[obj, member]
+		,
+		$Failed
+		,
+		Message[Unset::write, obj, obj@member]
+		,
+		TestID -> "protected: inheritable-only member: unsetMember evaluation"
+	];
+	
+	Test[
+		DownValues[obj]
+		,
+		downValues
+		,
+		TestID -> "protected: inheritable-only member: object down values"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*Unset inheritable delayed member*)
+
+
+Module[
+	{obj, member, value, downValues}
+	,
+	ObjectQ[obj] ^= True;
+	obj[member] := value;
+	obj[member, _] := value;
+	Protect[obj];
+	downValues = DownValues[obj];
+	
+	Test[
+		unsetMember[obj, member]
+		,
+		$Failed
+		,
+		Message[Unset::write, obj, obj@member]
+		,
+		TestID -> "protected: inheritable-only member: unsetMember evaluation"
+	];
+	
+	Test[
+		DownValues[obj]
+		,
+		downValues
+		,
+		TestID -> "protected: inheritable-only member: object down values"
 	];
 ]
 

--- a/ClasslessObjects/Tests/suite.mt
+++ b/ClasslessObjects/Tests/suite.mt
@@ -15,5 +15,6 @@ TestSuite[{
 	"Integration/MembersNoInheritance.mt",
 	"Integration/MembersOneLevelInheritance.mt",
 	"Integration/MembersTwoLevelInheritance.mt",
-	"Integration/MembersExplicitSelf.mt"
+	"Integration/MembersExplicitSelf.mt",
+	"Integration/ProtectedObjects.mt"
 }]


### PR DESCRIPTION
- Unprotect objects before changing `UpValues` and protect them afterward in `WithOrdinaryObjectSet`.
- Don't duplicate warning messages informing about inability of changing protected objects in `setMember`, `bindMember` and `unsetMember`.
- Add tests for above changes.

Fixes #1.
