### PR TITLE
Simplify Super storage

### DIFF
--- a/ClasslessObjects/ClasslessObjects.m
+++ b/ClasslessObjects/ClasslessObjects.m
@@ -164,6 +164,8 @@ fixArgumentsNumber[ObjectQ, 1]
 (*Super*)
 
 
+Super[_?ObjectQ] = Object
+
 Super[arg_ /; !ObjectQ[arg]] := "nothing" /;
 	Message[Object::object, HoldForm[1], HoldForm[Super[arg]]]
 
@@ -213,8 +215,6 @@ fixArgumentsNumber[Object, 2]
 
 
 ObjectQ[Object] ^= True
-
-Super[Object] ^= Object
 
 
 (* ::Subsection:: *)
@@ -282,7 +282,15 @@ SetSuper[obj_?ObjectQ, super_?ObjectQ] := (
 		]
 	];
 	
-	Super[obj] ^= super;
+	If[super === Object,
+		Quiet[
+			obj /: Super[obj] =.
+			,
+			TagUnset::norep
+		]
+	(* else *),
+		Super[obj] ^= super
+	];
 	
 	WithOrdinaryObjectSet[obj,
 		(* Delegate any undefinded member call to parent object. *)

--- a/ClasslessObjects/Tests/Unit/DeclareObject.mt
+++ b/ClasslessObjects/Tests/Unit/DeclareObject.mt
@@ -325,8 +325,6 @@ Module[
 		{
 			HoldPattern[HoldPattern][HoldPattern[ObjectQ][obj]] :> True
 			,
-			HoldPattern[HoldPattern][HoldPattern[Super][obj]] :> Object
-			,
 			Sequence @@ setAlteringUpValues[obj]
 		}
 		,

--- a/ClasslessObjects/Tests/Unit/SetSuper.mt
+++ b/ClasslessObjects/Tests/Unit/SetSuper.mt
@@ -472,9 +472,9 @@ Module[
 	Test[
 		FilterRules[UpValues[child], HoldPattern[HoldPattern][_Super]]
 		,
-		{HoldPattern[Super[child]] :> Object}
+		{}
 		,
-		TestID -> "Successful: remove parent: child has proper super up value"
+		TestID -> "Successful: remove parent: child has no super up value"
 	];
 	TestMatch[
 		DownValues[child]
@@ -498,6 +498,49 @@ child has proper inheritance down values"
 		oldDefinitionObject
 		,
 		TestID -> "Successful: remove parent: Object definition"
+	];
+]
+
+
+Module[
+	{child, parent, parentOldDefinition, oldDefinitionObject}
+	,
+	declareMockObject[child];
+	
+	{parentOldDefinition, oldDefinitionObject} =
+		ToString[Definition[#]]& /@ {parent, Object};
+
+	Test[
+		SetSuper[child, Object]
+		,
+		Null
+		,
+		TestID -> "Successful: reassign Object parent: SetSuper evaluation"
+	];
+	
+	Test[
+		FilterRules[UpValues[child], HoldPattern[HoldPattern][_Super]]
+		,
+		{}
+		,
+		TestID ->
+			"Successful: reassign Object parent: child has no super up value"
+	];
+	TestMatch[
+		DownValues[child]
+		,
+		inheritanceDownValues[child, Object]
+		,
+		TestID -> "Successful: reassign Object parent: \
+child has proper inheritance down values"
+	];
+	
+	Test[
+		ToString @ Definition[Object]
+		,
+		oldDefinitionObject
+		,
+		TestID -> "Successful: reassign Object parent: Object definition"
 	];
 ]
 

--- a/ClasslessObjects/Tests/Unit/Utilities.m
+++ b/ClasslessObjects/Tests/Unit/Utilities.m
@@ -54,7 +54,14 @@ Needs["ClasslessObjects`"]
 (*declareMockObject*)
 
 
-declareMockObject[obj_, super_:Object] := (
+declareMockObject[obj_] := (
+	ClearAll[obj];
+	
+	ObjectQ[obj] ^= True;
+)
+
+
+declareMockObject[obj_, super_] := (
 	ClearAll[obj];
 	
 	ObjectQ[obj] ^= True;


### PR DESCRIPTION
Don't store parent in objects up values if it's `Object` symbol.
Store default super (`Object`) in `Super` down value.
