### PR TITLE
Fix setting members of $self inside bound member

### DIFF
--- a/ClasslessObjects/ClasslessObjects.m
+++ b/ClasslessObjects/ClasslessObjects.m
@@ -372,13 +372,13 @@ bindMember[obj_?ObjectQ, lhs_, rhs_] :=
 		(* Don't duplicate SetDelayed::write warning if object is protected. *)
 		Quiet[
 			(* Inheritable definition providing $self variable. *)
-			obj[lhs, self_] := Block[{$self = self}, rhs]
+			obj[lhs, self_] := withBoundSelf[self, rhs]
 			,
 			SetDelayed::write
 		];
 		
 		(* Ordinary definition providing $self variable. *)
-		obj[lhs] := Block[{$self = obj}, rhs]
+		obj[lhs] := withBoundSelf[obj, rhs]
 	]
 
 

--- a/ClasslessObjects/ClasslessObjects.m
+++ b/ClasslessObjects/ClasslessObjects.m
@@ -107,6 +107,15 @@ returns list of ancestors of given object obj up to object ances if ances is \
 one of obj ancestors. Otherwise returns list of all ancestors."
 
 
+ClearAll[withBoundSelf]
+
+withBoundSelf::usage =
+"\
+withBoundSelf[self, body] \
+evaluates body with $self variable representing given object self. \
+Returns result of body evaluation."
+
+
 ClearAll[setMember]
 
 setMember::usage =
@@ -308,6 +317,25 @@ SetSuper[arg1_, arg2_ /; !ObjectQ[arg2]] := "nothing" /;
 	Message[Object::object, HoldForm[2], HoldForm[SetSuper[arg1, arg2]]]
 
 fixArgumentsNumber[SetSuper, 2]
+
+
+(* ::Subsection:: *)
+(*withBoundSelf*)
+
+
+SetAttributes[withBoundSelf, HoldRest]
+
+
+withBoundSelf[self_?ObjectQ, body_] :=
+	Block[
+		{$self = self}
+		,
+		$self /: Set[$self[lhs_], rhs_] := Set[self[lhs], rhs];
+		$self /: SetDelayed[$self[lhs_], rhs_] := SetDelayed[self[lhs], rhs];
+		$self /: Unset[$self[lhs_]] := Unset[self[lhs]];
+		
+		body
+	]
 
 
 (* ::Subsection:: *)

--- a/ClasslessObjects/Tests/Integration/MembersNoInheritance.mt
+++ b/ClasslessObjects/Tests/Integration/MembersNoInheritance.mt
@@ -13,9 +13,6 @@ BeginPackage[
 Get["ClasslessObjects`"]
 
 
-DeclareObject[obj]
-
-
 (* ::Section:: *)
 (*Tests*)
 
@@ -24,47 +21,110 @@ DeclareObject[obj]
 (*Non-existing member*)
 
 
-Test[
-	obj@field
+Module[
+	{obj, member}
 	,
-	$Failed
+	DeclareObject[obj];
+	
+	
+	Test[
+		obj@member
+		,
+		$Failed
+		,
+		Message[Object::objectMember, obj, member, {Object}]
+		,
+		TestID -> "Non-existing member: call symbol"
+	]
+]
+Module[
+	{obj, otherObj, member}
 	,
-	Message[Object::objectMember, obj, field, {Object}]
-	,
-	TestID -> "Non-existing member: call symbol"
+	DeclareObject[obj];
+	DeclareObject[otherObj];
+	
+	
+	Test[
+		obj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Non-existing member: call symbol: explicit self"
+	]
 ]
 
 
-Test[
-	obj@addSome[5]
+Module[
+	{obj, member, arg}
 	,
-	$Failed
+	DeclareObject[obj];
+	
+	
+	Test[
+		obj@member[arg]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, obj, member[arg], {Object}]
+		,
+		TestID -> "Non-existing member: call non-atomic expression"
+	]
+]
+Module[
+	{obj, otherObj, member, arg}
 	,
-	Message[Object::objectMember, obj, addSome[5], {Object}]
-	,
-	TestID -> "Non-existing member: call non-atomic expression"
+	DeclareObject[obj];
+	DeclareObject[otherObj];
+	
+	
+	Test[
+		obj[member[arg], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member[arg], {Object}]
+		,
+		TestID ->
+			"Non-existing member: call non-atomic expression: explicit self"
+	]
 ]
 
 
-Test[
-	obj@field =.
+Module[
+	{obj, member}
 	,
-	$Failed
-	,
-	Message[Unset::norep, obj[field], obj]
-	,
-	TestID -> "Non-existing member: unset symbol"
+	DeclareObject[obj];
+	
+	
+	Test[
+		obj@member =.
+		,
+		$Failed
+		,
+		Message[Unset::norep, obj@member, obj]
+		,
+		TestID -> "Non-existing member: unset symbol"
+	]
 ]
 
 
-Test[
-	obj@addSome[5] =.
+Module[
+	{obj, member, arg}
 	,
-	$Failed
-	,
-	Message[Unset::norep, obj[addSome[5]], obj]
-	,
-	TestID -> "Non-existing member: unset non-atomic expression"
+	DeclareObject[obj];
+	
+	
+	Test[
+		obj@member[arg] =.
+		,
+		$Failed
+		,
+		Message[Unset::norep, obj@member[arg], obj]
+		,
+		TestID -> "Non-existing member: unset non-atomic expression"
+	]
 ]
 
 
@@ -72,41 +132,62 @@ Test[
 (*Unbound member*)
 
 
-Test[
-	obj@field = 5
+Module[
+	{obj, otherObj, member, value}
 	,
-	5
-	,
-	TestID -> "Unbound member: set"
-]
-
-
-Test[
-	obj@field
-	,
-	5
-	,
-	TestID -> "Unbound member: call existing"
-]
-
-
-Test[
-	obj@field =.
-	,
-	Null
-	,
-	TestID -> "Unbound member: unset"
-]
-
-
-Test[
-	obj@field
-	,
-	$Failed
-	,
-	Message[Object::objectMember, obj, field, {Object}]
-	,
-	TestID -> "Unbound member: call unset"
+	DeclareObject[obj];
+	DeclareObject[otherObj];
+	
+	
+	Test[
+		obj@member = value
+		,
+		value
+		,
+		TestID -> "Unbound member: set"
+	];
+	
+	Test[
+		obj@member
+		,
+		value
+		,
+		TestID -> "Unbound member: call existing"
+	];
+	Test[
+		obj[member, otherObj]
+		,
+		value
+		,
+		TestID -> "Unbound member: call existing: explicit self"
+	];
+	
+	Test[
+		obj@member =.
+		,
+		Null
+		,
+		TestID -> "Unbound member: unset"
+	];
+	
+	Test[
+		obj@member
+		,
+		$Failed
+		,
+		Message[Object::objectMember, obj, member, {Object}]
+		,
+		TestID -> "Unbound member: call unset"
+	];
+	Test[
+		obj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Unbound member: call unset: explicit self"
+	];
 ]
 
 
@@ -114,41 +195,62 @@ Test[
 (*Unbound member with $self*)
 
 
-Test[
-	obj@self = $self
+Module[
+	{obj, otherObj, member, value}
 	,
-	$self
-	,
-	TestID -> "Unbound member with $self: set"
-]
-
-
-TestMatch[
-	obj@self
-	,
-	HoldPattern[$self]
-	,
-	TestID -> "Unbound member with $self: call existing"
-]
-
-
-Test[
-	obj@self =.
-	,
-	Null
-	,
-	TestID -> "Unbound member with $self: unset"
-]
-
-
-Test[
-	obj@self
-	,
-	$Failed
-	,
-	Message[Object::objectMember, obj, self, {Object}]
-	,
-	TestID -> "Unbound member with $self: call unset"
+	DeclareObject[obj];
+	DeclareObject[otherObj];
+	
+	
+	Test[
+		obj@member = {value, $self}
+		,
+		{value, $self}
+		,
+		TestID -> "Unbound member with $self: set"
+	];
+	
+	TestMatch[
+		obj@member
+		,
+		HoldPattern[{value, $self}]
+		,
+		TestID -> "Unbound member with $self: call existing"
+	];
+	TestMatch[
+		obj[member, otherObj]
+		,
+		HoldPattern[{value, $self}]
+		,
+		TestID -> "Unbound member with $self: call existing: explicit self"
+	];
+	
+	Test[
+		obj@member =.
+		,
+		Null
+		,
+		TestID -> "Unbound member with $self: unset"
+	];
+	
+	Test[
+		obj@member
+		,
+		$Failed
+		,
+		Message[Object::objectMember, obj, member, {Object}]
+		,
+		TestID -> "Unbound member with $self: call unset"
+	];
+	Test[
+		obj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Unbound member with $self: call unset: explicit self"
+	];
 ]
 
 
@@ -156,52 +258,84 @@ Test[
 (*Bound member*)
 
 
-Test[
-	obj@addSome[i_Integer] := i + 2
+Module[
+	{obj, otherObj, member, value, arg}
 	,
-	Null
-	,
-	TestID -> "Bound member: set"
-]
-
-
-Test[
-	obj@addSome[5]
-	,
-	7
-	,
-	TestID -> "Bound member: call existing"
-]
-
-
-Test[
-	obj@addSome["test string"]
-	,
-	$Failed
-	,
-	Message[Object::objectMember, obj, addSome["test string"], {Object}]
-	,
-	TestID -> "Bound member: call non-existing with head same as existing"
-]
-
-
-Test[
-	obj@addSome[i_Integer] =.
-	,
-	Null
-	,
-	TestID -> "Bound member: unset"
-]
-
-
-Test[
-	obj@addSome[5]
-	,
-	$Failed
-	,
-	Message[Object::objectMember, obj, addSome[5], {Object}]
-	,
-	TestID -> "Bound member: call unset"
+	DeclareObject[obj];
+	DeclareObject[otherObj];
+	
+	
+	Test[
+		obj@member[i_Symbol] := {value, i}
+		,
+		Null
+		,
+		TestID -> "Bound member: set"
+	];
+	
+	Test[
+		obj@member[arg]
+		,
+		{value, arg}
+		,
+		TestID -> "Bound member: call existing"
+	];
+	Test[
+		obj[member[arg], otherObj]
+		,
+		{value, arg}
+		,
+		TestID -> "Bound member: call existing: explicit self"
+	];
+	
+	Test[
+		obj@member["test string"]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, obj, member["test string"], {Object}]
+		,
+		TestID -> "Bound member: call non-existing with head same as existing"
+	];
+	Test[
+		obj[member["test string"], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			otherObj, member["test string"], {Object}
+		]
+		,
+		TestID -> "Bound member: \
+call non-existing with head same as existing: explicit self"
+	];
+	
+	Test[
+		obj@member[i_Symbol] =.
+		,
+		Null
+		,
+		TestID -> "Bound member: unset"
+	];
+	
+	Test[
+		obj@member[arg]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, obj, member[arg], {Object}]
+		,
+		TestID -> "Bound member: call unset"
+	];
+	Test[
+		obj[member[arg], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member[arg], {Object}]
+		,
+		TestID -> "Bound member: call unset: explicit self"
+	];
 ]
 
 
@@ -209,53 +343,214 @@ Test[
 (*Bound member with $self*)
 
 
-Test[
-	obj@getSelf[] := $self
+Module[
+	{obj, otherObj, member, value, arg}
 	,
-	Null
-	,
-	TestID -> "Bound member with $self: set"
+	DeclareObject[obj];
+	DeclareObject[otherObj];
+	
+	Test[
+		obj@member[] := {value, $self}
+		,
+		Null
+		,
+		TestID -> "Bound member with $self: set"
+	];
+	
+	Test[
+		obj@member[]
+		,
+		{value, obj}
+		,
+		TestID -> "Bound member with $self: call existing"
+	];
+	Test[
+		obj[member[], otherObj]
+		,
+		{value, otherObj}
+		,
+		TestID -> "Bound member with $self: call existing: explicit self"
+	];
+	
+	Test[
+		obj@member[arg]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, obj, member[arg], {Object}]
+		,
+		TestID -> "Bound member with $self: \
+call non-existing with head same as existing"
+	];
+	Test[
+		obj[member[arg], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member[arg], {Object}]
+		,
+		TestID -> "Bound member with $self: \
+call non-existing with head same as existing: explicit self"
+	];
+	
+	Test[
+		obj@member[] =.
+		,
+		Null
+		,
+		TestID -> "Bound member with $self: unset"
+	];
+	
+	Test[
+		obj@member[]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, obj, member[], {Object}]
+		,
+		TestID -> "Bound member with $self: call unset"
+	];
+	Test[
+		obj[member[], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member[], {Object}]
+		,
+		TestID -> "Bound member with $self: call unset: explicit self"
+	];
 ]
 
 
-Test[
-	obj@getSelf[]
+(* ::Subsection:: *)
+(*Non-inheritable member*)
+
+
+Module[
+	{obj, otherObj, member, value}
 	,
-	obj
-	,
-	TestID -> "Bound member with $self: call existing"
+	DeclareObject[obj];
+	DeclareObject[otherObj];
+	
+	Test[
+		WithOrdinaryObjectSet[obj,
+			obj@member = value
+		]
+		,
+		value
+		,
+		TestID -> "Non-inheritable member: set"
+	];
+	
+	Test[
+		obj@member
+		,
+		value
+		,
+		TestID -> "Non-inheritable member: call existing"
+	];
+	Test[
+		obj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable member: call existing: explicit self"
+	];
+	
+	Test[
+		obj@member =.
+		,
+		Null
+		,
+		TestID -> "Non-inheritable member: unset"
+	];
+	
+	Test[
+		obj@member
+		,
+		$Failed
+		,
+		Message[Object::objectMember, obj, member, {Object}]
+		,
+		TestID -> "Non-inheritable member: call unset"
+	];
+	Test[
+		obj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable member: call unset: explicit self"
+	];
 ]
 
 
-Test[
-	obj@getSelf[5]
-	,
-	$Failed
-	,
-	Message[Object::objectMember, obj, getSelf[5], {Object}]
-	,
-	TestID ->
-		"Bound member with $self: call non-existing with head same as existing"
-]
+(* ::Subsection:: *)
+(*Inheritable-only member*)
 
 
-Test[
-	obj@getSelf[] =.
+Module[
+	{obj, otherObj, member, value}
 	,
-	Null
-	,
-	TestID -> "Bound member with $self: unset"
-]
-
-
-Test[
-	obj@getSelf[]
-	,
-	$Failed
-	,
-	Message[Object::objectMember, obj, getSelf[], {Object}]
-	,
-	TestID -> "Bound member with $self: call unset"
+	DeclareObject[obj];
+	DeclareObject[otherObj];
+	
+	Test[
+		WithOrdinaryObjectSet[obj,
+			obj[member[], self_] := {value, self}
+		]
+		,
+		Null
+		,
+		TestID -> "Inheritable-only member: set"
+	];
+	
+	Test[
+		obj@member[]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, obj, member[], {Object}]
+		,
+		TestID -> "Inheritable-only member: call existing"
+	];
+	Test[
+		obj[member[], otherObj]
+		,
+		{value, otherObj}
+		,
+		TestID -> "Inheritable-only member: call existing: explicit self"
+	];
+	
+	Test[
+		obj@member[] =.
+		,
+		Null
+		,
+		TestID -> "Inheritable-only member: unset"
+	];
+	
+	Test[
+		obj@member[]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, obj, member[], {Object}]
+		,
+		TestID -> "Inheritable-only member: call unset"
+	];
+	Test[
+		obj[member[], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member[], {Object}]
+		,
+		TestID -> "Inheritable-only member: call unset: explicit self"
+	];
 ]
 
 

--- a/ClasslessObjects/Tests/Integration/SettersNoInheritance.mt
+++ b/ClasslessObjects/Tests/Integration/SettersNoInheritance.mt
@@ -1,0 +1,495 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage[
+	"ClasslessObjects`Tests`Integration`SettersNoInheritance`",
+	{"MUnit`"}
+]
+
+
+Get["ClasslessObjects`"]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+(* ::Subsection:: *)
+(*Unbound inheritable*)
+
+
+Module[
+	{setterObj, otherObj, member, setter, arg}
+	,
+	DeclareObject[setterObj];
+	DeclareObject[otherObj];
+	setterObj@setter[x_] := ($self@member = {$self, x});
+	
+	Test[
+		setterObj@setter[arg]
+		,
+		{setterObj, arg}
+		,
+		TestID -> "Unbound inheritable: setter implicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member
+		,
+		{setterObj, arg}
+		,
+		TestID -> "Unbound inheritable: setter implicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member, otherObj]
+		,
+		{setterObj, arg}
+		,
+		TestID -> "Unbound inheritable: setter implicit self: \
+call member setterObj: explicit self"
+	];
+]
+
+Module[
+	{setterObj, explSelfObj, otherObj, member, setter, arg}
+	,
+	DeclareObject[setterObj];
+	DeclareObject[explSelfObj];
+	DeclareObject[otherObj];
+	setterObj@setter[x_] := ($self@member = {$self, x});
+	
+	Test[
+		setterObj[setter[arg], explSelfObj]
+		,
+		{explSelfObj, arg}
+		,
+		TestID -> "Unbound inheritable: setter explicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member, {Object}]
+		,
+		TestID -> "Unbound inheritable: setter explicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Unbound inheritable: setter explicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member, explSelfObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member, {Object}]
+		,
+		TestID -> "Unbound inheritable: setter explicit self: \
+call member setterObj: explicit self explSelfObj"
+	];
+	
+	Test[
+		explSelfObj@member
+		,
+		{explSelfObj, arg}
+		,
+		TestID -> "Unbound inheritable: setter explicit self: \
+call member explSelfObj"
+	];
+	Test[
+		explSelfObj[member, otherObj]
+		,
+		{explSelfObj, arg}
+		,
+		TestID -> "Unbound inheritable: setter explicit self: \
+call member explSelfObj: explicit self otherObj"
+	];
+	Test[
+		explSelfObj[member, setterObj]
+		,
+		{explSelfObj, arg}
+		,
+		TestID -> "Unbound inheritable: setter explicit self: \
+call member explSelfObj: explicit self setterObj"
+	];
+]
+
+
+(* ::Subsection:: *)
+(*Bound inheritable*)
+
+
+Module[
+	{setterObj, otherObj, member, setter, arg, arg2}
+	,
+	DeclareObject[setterObj];
+	DeclareObject[otherObj];
+	setterObj@setter[x_] := ($self@member[y_] := {$self, x, y});
+	
+	Test[
+		setterObj@setter[arg]
+		,
+		Null
+		,
+		TestID -> "Bound inheritable: setter implicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member[arg2]
+		,
+		{setterObj, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setter implicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member[arg2], otherObj]
+		,
+		{otherObj, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setter implicit self: \
+call member setterObj: explicit self"
+	];
+]
+
+Module[
+	{setterObj, explSelfObj, otherObj, member, setter, arg, arg2}
+	,
+	DeclareObject[setterObj];
+	DeclareObject[explSelfObj];
+	DeclareObject[otherObj];
+	setterObj@setter[x_] := ($self@member[y_] := {$self, x, y});
+	
+	Test[
+		setterObj[setter[arg], explSelfObj]
+		,
+		Null
+		,
+		TestID -> "Bound inheritable: setter explicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member[arg2]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member[arg2], {Object}]
+		,
+		TestID -> "Bound inheritable: setter explicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member[arg2], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member[arg2], {Object}]
+		,
+		TestID -> "Bound inheritable: setter explicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member[arg2], explSelfObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member[arg2], {Object}]
+		,
+		TestID -> "Bound inheritable: setter explicit self: \
+call member setterObj: explicit self explSelfObj"
+	];
+	
+	Test[
+		explSelfObj@member[arg2]
+		,
+		{explSelfObj, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setter explicit self: \
+call member explSelfObj"
+	];
+	Test[
+		explSelfObj[member[arg2], otherObj]
+		,
+		{otherObj, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setter explicit self: \
+call member explSelfObj: explicit self otherObj"
+	];
+	Test[
+		explSelfObj[member[arg2], setterObj]
+		,
+		{setterObj, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setter explicit self: \
+call member explSelfObj: explicit self setterObj"
+	];
+]
+
+
+(* ::Subsection:: *)
+(*Non-inheritable*)
+
+
+Module[
+	{setterObj, otherObj, member, setter, arg}
+	,
+	DeclareObject[setterObj];
+	DeclareObject[otherObj];
+	setterObj@setter[x_] :=
+		WithOrdinaryObjectSet[$self,
+			$self@member = {$self, x}
+		];
+	
+	Test[
+		setterObj@setter[arg]
+		,
+		{setterObj, arg}
+		,
+		TestID -> "Non-inheritable: setter implicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member
+		,
+		{setterObj, arg}
+		,
+		TestID -> "Non-inheritable: setter implicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setter implicit self: \
+call member setterObj: explicit self"
+	];
+]
+
+Module[
+	{setterObj, explSelfObj, otherObj, member, setter, arg}
+	,
+	DeclareObject[setterObj];
+	DeclareObject[explSelfObj];
+	DeclareObject[otherObj];
+	setterObj@setter[x_] :=
+		WithOrdinaryObjectSet[$self,
+			$self@member = {$self, x}
+		];
+	
+	Test[
+		setterObj[setter[arg], explSelfObj]
+		,
+		{explSelfObj, arg}
+		,
+		TestID -> "Non-inheritable: setter explicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setter explicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setter explicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member, explSelfObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setter explicit self: \
+call member setterObj: explicit self explSelfObj"
+	];
+	
+	Test[
+		explSelfObj@member
+		,
+		{explSelfObj, arg}
+		,
+		TestID -> "Non-inheritable: setter explicit self: \
+call member explSelfObj"
+	];
+	Test[
+		explSelfObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setter explicit self: \
+call member explSelfObj: explicit self otherObj"
+	];
+	Test[
+		explSelfObj[member, setterObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setter explicit self: \
+call member explSelfObj: explicit self setterObj"
+	];
+]
+
+
+(* ::Subsection:: *)
+(*Inheritable-only*)
+
+
+Module[
+	{setterObj, otherObj, member, setter, arg, arg2}
+	,
+	DeclareObject[setterObj];
+	DeclareObject[otherObj];
+	setterObj@setter[x_] :=
+		WithOrdinaryObjectSet[$self,
+			$self[member[y_], self_] := {$self, self, x, y}
+		];
+	
+	Test[
+		setterObj@setter[arg]
+		,
+		Null
+		,
+		TestID -> "Inheritable-only: setter implicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member[arg2]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setter implicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member[arg2], otherObj]
+		,
+		{$self, otherObj, arg, arg2}
+		,
+		TestID -> "Inheritable-only: setter implicit self: \
+call member setterObj: explicit self"
+	];
+]
+
+Module[
+	{setterObj, explSelfObj, otherObj, member, setter, arg, arg2}
+	,
+	DeclareObject[setterObj];
+	DeclareObject[explSelfObj];
+	DeclareObject[otherObj];
+	setterObj@setter[x_] :=
+		WithOrdinaryObjectSet[$self,
+			$self[member[y_], self_] := {$self, self, x, y}
+		];
+	
+	Test[
+		setterObj[setter[arg], explSelfObj]
+		,
+		Null
+		,
+		TestID -> "Inheritable-only: setter explicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member[arg2]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setter explicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member[arg2], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setter explicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member[arg2], explSelfObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setter explicit self: \
+call member setterObj: explicit self explSelfObj"
+	];
+	
+	Test[
+		explSelfObj@member[arg2]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setter explicit self: \
+call member explSelfObj"
+	];
+	Test[
+		explSelfObj[member[arg2], otherObj]
+		,
+		{$self, otherObj, arg, arg2}
+		,
+		TestID -> "Inheritable-only: setter explicit self: \
+call member explSelfObj: explicit self otherObj"
+	];
+	Test[
+		explSelfObj[member[arg2], setterObj]
+		,
+		{$self, setterObj, arg, arg2}
+		,
+		TestID -> "Inheritable-only: setter explicit self: \
+call member explSelfObj: explicit self setterObj"
+	];
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/ClasslessObjects/Tests/Integration/SettersOneLevelInheritance.mt
+++ b/ClasslessObjects/Tests/Integration/SettersOneLevelInheritance.mt
@@ -1,0 +1,1269 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage[
+	"ClasslessObjects`Tests`Integration`SettersOneLevelInheritance`",
+	{"MUnit`"}
+]
+
+
+Get["ClasslessObjects`"]
+
+
+setUpObjects[setterObj_, setterChildObj_, otherObj_] := (
+	DeclareObject[setterObj];
+	DeclareObject[setterChildObj, setterObj];
+	DeclareObject[otherObj];
+)
+
+setUpObjects[setterObj_, setterChildObj_, explSelfObj_, otherObj_] := (
+	setUpObjects[setterObj, setterChildObj, otherObj];
+	DeclareObject[explSelfObj];
+)
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+(* ::Subsection:: *)
+(*Unbound inheritable*)
+
+
+(* ::Subsubsection:: *)
+(*setterObj implicit self*)
+
+
+Module[
+	{setterObj, setterChildObj, otherObj, member, setter, arg}
+	,
+	setUpObjects[setterObj, setterChildObj, otherObj];
+	setterObj@setter[x_] := ($self@member = {$self, Super[$self], x});
+	
+	Test[
+		setterObj@setter[arg]
+		,
+		{setterObj, Object, arg}
+		,
+		TestID -> "Unbound inheritable: setterObj implicit self: \
+call setter"
+	];
+	
+	Test[
+		setterObj@member
+		,
+		{setterObj, Object, arg}
+		,
+		TestID -> "Unbound inheritable: setterObj implicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member, otherObj]
+		,
+		{setterObj, Object, arg}
+		,
+		TestID -> "Unbound inheritable: setterObj implicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member, setterChildObj]
+		,
+		{setterObj, Object, arg}
+		,
+		TestID -> "Unbound inheritable: setterObj implicit self: \
+call member setterObj: explicit self setterChildObj"
+	];
+	
+	Test[
+		setterChildObj@member
+		,
+		{setterObj, Object, arg}
+		,
+		TestID -> "Unbound inheritable: setterObj implicit self: \
+call member setterChildObj"
+	];
+	Test[
+		setterChildObj[member, otherObj]
+		,
+		{setterObj, Object, arg}
+		,
+		TestID -> "Unbound inheritable: setterObj implicit self: \
+call member setterChildObj: explicit self otherObj"
+	];
+	Test[
+		setterChildObj[member, setterObj]
+		,
+		{setterObj, Object, arg}
+		,
+		TestID -> "Unbound inheritable: setterObj implicit self: \
+call member setterChildObj: explicit self setterObj"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*setterChildObj implicit self*)
+
+
+Module[
+	{setterObj, setterChildObj, otherObj, member, setter, arg}
+	,
+	setUpObjects[setterObj, setterChildObj, otherObj];
+	setterObj@setter[x_] := ($self@member = {$self, Super[$self], x});
+	
+	Test[
+		setterChildObj@setter[arg]
+		,
+		{setterChildObj, setterObj, arg}
+		,
+		TestID -> "Unbound inheritable: setterChildObj implicit self: \
+call setter"
+	];
+	
+	Test[
+		setterObj@member
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member, {Object}]
+		,
+		TestID -> "Unbound inheritable: setterChildObj implicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Unbound inheritable: setterChildObj implicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member, setterChildObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member, {setterObj, Object}
+		]
+		,
+		TestID -> "Unbound inheritable: setterChildObj implicit self: \
+call member setterObj: explicit self setterChildObj"
+	];
+	
+	Test[
+		setterChildObj@member
+		,
+		{setterChildObj, setterObj, arg}
+		,
+		TestID -> "Unbound inheritable: setterChildObj implicit self: \
+call member setterChildObj"
+	];
+	Test[
+		setterChildObj[member, otherObj]
+		,
+		{setterChildObj, setterObj, arg}
+		,
+		TestID -> "Unbound inheritable: setterChildObj implicit self: \
+call member setterChildObj: explicit self otherObj"
+	];
+	Test[
+		setterChildObj[member, setterObj]
+		,
+		{setterChildObj, setterObj, arg}
+		,
+		TestID -> "Unbound inheritable: setterChildObj implicit self: \
+call member setterChildObj: explicit self setterObj"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*setterChildObj explicit self*)
+
+
+Module[
+	{setterObj, setterChildObj, explSelfObj, otherObj, member, setter, arg}
+	,
+	setUpObjects[setterObj, setterChildObj, explSelfObj, otherObj];
+	setterObj@setter[x_] := ($self@member = {$self, Super[$self], x});
+	
+	Test[
+		setterChildObj[setter[arg], explSelfObj]
+		,
+		{explSelfObj, Object, arg}
+		,
+		TestID -> "Unbound inheritable: setterChildObj explicit self: \
+call setter"
+	];
+	
+	Test[
+		setterObj@member
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member, {Object}]
+		,
+		TestID -> "Unbound inheritable: setterChildObj explicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Unbound inheritable: setterChildObj explicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member, explSelfObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member, {Object}]
+		,
+		TestID -> "Unbound inheritable: setterChildObj explicit self: \
+call member setterObj: explicit self explSelfObj"
+	];
+	Test[
+		setterObj[member, setterChildObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member, {setterObj, Object}
+		]
+		,
+		TestID -> "Unbound inheritable: setterChildObj explicit self: \
+call member setterObj: explicit self setterChildObj"
+	];
+	
+	Test[
+		setterChildObj@member
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member, {setterObj, Object}
+		]
+		,
+		TestID -> "Unbound inheritable: setterChildObj explicit self: \
+call member setterChildObj"
+	];
+	Test[
+		setterChildObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Unbound inheritable: setterChildObj explicit self: \
+call member setterChildObj: explicit self otherObj"
+	];
+	Test[
+		setterChildObj[member, explSelfObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member, {Object}]
+		,
+		TestID -> "Unbound inheritable: setterChildObj explicit self: \
+call member setterChildObj: explicit self explSelfObj"
+	];
+	Test[
+		setterChildObj[member, setterObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member, {Object}]
+		,
+		TestID -> "Unbound inheritable: setterChildObj explicit self: \
+call member setterChildObj: explicit self setterObj"
+	];
+	
+	Test[
+		explSelfObj@member
+		,
+		{explSelfObj, Object, arg}
+		,
+		TestID -> "Unbound inheritable: setterChildObj explicit self: \
+call member explSelfObj"
+	];
+	Test[
+		explSelfObj[member, otherObj]
+		,
+		{explSelfObj, Object, arg}
+		,
+		TestID -> "Unbound inheritable: setterChildObj explicit self: \
+call member explSelfObj: explicit self otherObj"
+	];
+	Test[
+		explSelfObj[member, setterObj]
+		,
+		{explSelfObj, Object, arg}
+		,
+		TestID -> "Unbound inheritable: setterChildObj explicit self: \
+call member explSelfObj: explicit self setterObj"
+	];
+	Test[
+		explSelfObj[member, setterChildObj]
+		,
+		{explSelfObj, Object, arg}
+		,
+		TestID -> "Unbound inheritable: setterChildObj explicit self: \
+call member explSelfObj: explicit self setterChildObj"
+	];
+]
+
+
+(* ::Subsection:: *)
+(*Bound inheritable*)
+
+
+(* ::Subsubsection:: *)
+(*setterObj implicit self*)
+
+
+Module[
+	{setterObj, setterChildObj, otherObj, member, setter, arg, arg2}
+	,
+	setUpObjects[setterObj, setterChildObj, otherObj];
+	setterObj@setter[x_] := ($self@member[y_] := {$self, Super[$self], x, y});
+	
+	Test[
+		setterObj@setter[arg]
+		,
+		Null
+		,
+		TestID -> "Bound inheritable: setterObj implicit self: \
+call setter"
+	];
+	
+	Test[
+		setterObj@member[arg2]
+		,
+		{setterObj, Object, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setterObj implicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member[arg2], otherObj]
+		,
+		{otherObj, Object, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setterObj implicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member[arg2], setterChildObj]
+		,
+		{setterChildObj, setterObj, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setterObj implicit self: \
+call member setterObj: explicit self setterChildObj"
+	];
+	
+	Test[
+		setterChildObj@member[arg2]
+		,
+		{setterChildObj, setterObj, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setterObj implicit self: \
+call member setterChildObj"
+	];
+	Test[
+		setterChildObj[member[arg2], otherObj]
+		,
+		{otherObj, Object, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setterObj implicit self: \
+call member setterChildObj: explicit self otherObj"
+	];
+	Test[
+		setterChildObj[member[arg2], setterObj]
+		,
+		{setterObj, Object, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setterObj implicit self: \
+call member setterChildObj: explicit self setterObj"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*setterChildObj implicit self*)
+
+
+Module[
+	{setterObj, setterChildObj, otherObj, member, setter, arg, arg2}
+	,
+	setUpObjects[setterObj, setterChildObj, otherObj];
+	setterObj@setter[x_] := ($self@member[y_] := {$self, Super[$self], x, y});
+	
+	Test[
+		setterChildObj@setter[arg]
+		,
+		Null
+		,
+		TestID -> "Bound inheritable: setterChildObj implicit self: \
+call setter"
+	];
+	
+	Test[
+		setterObj@member[arg2]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member[arg2], {Object}]
+		,
+		TestID -> "Bound inheritable: setterChildObj implicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member[arg2], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member[arg2], {Object}]
+		,
+		TestID -> "Bound inheritable: setterChildObj implicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member[arg2], setterChildObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member[arg2], {setterObj, Object}
+		]
+		,
+		TestID -> "Bound inheritable: setterChildObj implicit self: \
+call member setterObj: explicit self setterChildObj"
+	];
+	
+	Test[
+		setterChildObj@member[arg2]
+		,
+		{setterChildObj, setterObj, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setterChildObj implicit self: \
+call member setterChildObj"
+	];
+	Test[
+		setterChildObj[member[arg2], otherObj]
+		,
+		{otherObj, Object, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setterChildObj implicit self: \
+call member setterChildObj: explicit self otherObj"
+	];
+	Test[
+		setterChildObj[member[arg2], setterObj]
+		,
+		{setterObj, Object, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setterChildObj implicit self: \
+call member setterChildObj: explicit self setterObj"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*setterChildObj explicit self*)
+
+
+Module[
+	{
+		setterObj, setterChildObj, explSelfObj, otherObj,
+		member, setter, arg, arg2
+	}
+	,
+	setUpObjects[setterObj, setterChildObj, explSelfObj, otherObj];
+	setterObj@setter[x_] := ($self@member[y_] := {$self, Super[$self], x, y});
+	
+	Test[
+		setterChildObj[setter[arg], explSelfObj]
+		,
+		Null
+		,
+		TestID -> "Bound inheritable: setterChildObj explicit self: \
+call setter"
+	];
+	
+	Test[
+		setterObj@member[arg2]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member[arg2], {Object}]
+		,
+		TestID -> "Bound inheritable: setterChildObj explicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member[arg2], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member[arg2], {Object}]
+		,
+		TestID -> "Bound inheritable: setterChildObj explicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member[arg2], explSelfObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member[arg2], {Object}]
+		,
+		TestID -> "Bound inheritable: setterChildObj explicit self: \
+call member setterObj: explicit self explSelfObj"
+	];
+	Test[
+		setterObj[member[arg2], setterChildObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member[arg2], {setterObj, Object}
+		]
+		,
+		TestID -> "Bound inheritable: setterChildObj explicit self: \
+call member setterObj: explicit self setterChildObj"
+	];
+	
+	Test[
+		setterChildObj@member[arg2]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member[arg2], {setterObj, Object}
+		]
+		,
+		TestID -> "Bound inheritable: setterChildObj explicit self: \
+call member setterChildObj"
+	];
+	Test[
+		setterChildObj[member[arg2], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member[arg2], {Object}]
+		,
+		TestID -> "Bound inheritable: setterChildObj explicit self: \
+call member setterChildObj: explicit self otherObj"
+	];
+	Test[
+		setterChildObj[member[arg2], explSelfObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member[arg2], {Object}]
+		,
+		TestID -> "Bound inheritable: setterChildObj explicit self: \
+call member setterChildObj: explicit self explSelfObj"
+	];
+	Test[
+		setterChildObj[member[arg2], setterObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member[arg2], {Object}]
+		,
+		TestID -> "Bound inheritable: setterChildObj explicit self: \
+call member setterChildObj: explicit self setterObj"
+	];
+	
+	Test[
+		explSelfObj@member[arg2]
+		,
+		{explSelfObj, Object, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setterChildObj explicit self: \
+call member explSelfObj"
+	];
+	Test[
+		explSelfObj[member[arg2], otherObj]
+		,
+		{otherObj, Object, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setterChildObj explicit self: \
+call member explSelfObj: explicit self otherObj"
+	];
+	Test[
+		explSelfObj[member[arg2], setterObj]
+		,
+		{setterObj, Object, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setterChildObj explicit self: \
+call member explSelfObj: explicit self setterObj"
+	];
+	Test[
+		explSelfObj[member[arg2], setterChildObj]
+		,
+		{setterChildObj, setterObj, arg, arg2}
+		,
+		TestID -> "Bound inheritable: setterChildObj explicit self: \
+call member explSelfObj: explicit self setterObj"
+	];
+]
+
+
+(* ::Subsection:: *)
+(*Non-inheritable*)
+
+
+(* ::Subsubsection:: *)
+(*setterObj implicit self*)
+
+
+Module[
+	{setterObj, setterChildObj, otherObj, member, setter, arg}
+	,
+	setUpObjects[setterObj, setterChildObj, otherObj];
+	setterObj@setter[x_] :=
+		WithOrdinaryObjectSet[$self,
+			$self@member = {$self, Super[$self], x}
+		];
+	
+	Test[
+		setterObj@setter[arg]
+		,
+		{setterObj, Object, arg}
+		,
+		TestID -> "Non-inheritable: setterObj implicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member
+		,
+		{setterObj, Object, arg}
+		,
+		TestID -> "Non-inheritable: setterObj implicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterObj implicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member, setterChildObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member, {setterObj, Object}
+		]
+		,
+		TestID -> "Non-inheritable: setterObj implicit self: \
+call member setterObj: explicit self setterChildObj"
+	];
+	
+	Test[
+		setterChildObj@member
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member, {setterObj, Object}
+		]
+		,
+		TestID -> "Non-inheritable: setterObj implicit self: \
+call member setterChildObj"
+	];
+	Test[
+		setterChildObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterObj implicit self: \
+call member setterChildObj: explicit self otherObj"
+	];
+	Test[
+		setterChildObj[member, setterObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterObj implicit self: \
+call member setterChildObj: explicit self setterObj"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*setterChildObj implicit self*)
+
+
+Module[
+	{setterObj, setterChildObj, otherObj, member, setter, arg}
+	,
+	setUpObjects[setterObj, setterChildObj, otherObj];
+	setterObj@setter[x_] :=
+		WithOrdinaryObjectSet[$self,
+			$self@member = {$self, Super[$self], x}
+		];
+	
+	Test[
+		setterChildObj@setter[arg]
+		,
+		{setterChildObj, setterObj, arg}
+		,
+		TestID -> "Non-inheritable: setterChildObj implicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterChildObj implicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterChildObj implicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member, setterChildObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member, {setterObj, Object}
+		]
+		,
+		TestID -> "Non-inheritable: setterChildObj implicit self: \
+call member setterObj: explicit self setterChildObj"
+	];
+	
+	Test[
+		setterChildObj@member
+		,
+		{setterChildObj, setterObj, arg}
+		,
+		TestID -> "Non-inheritable: setterChildObj implicit self: \
+call member setterChildObj"
+	];
+	Test[
+		setterChildObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterChildObj implicit self: \
+call member setterChildObj: explicit self otherObj"
+	];
+	Test[
+		setterChildObj[member, setterObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterChildObj implicit self: \
+call member setterChildObj: explicit self setterObj"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*setterChildObj explicit self*)
+
+
+Module[
+	{setterObj, setterChildObj, explSelfObj, otherObj, member, setter, arg}
+	,
+	setUpObjects[setterObj, setterChildObj, explSelfObj, otherObj];
+	setterObj@setter[x_] :=
+		WithOrdinaryObjectSet[$self,
+			$self@member = {$self, Super[$self], x}
+		];
+	
+	Test[
+		setterChildObj[setter[arg], explSelfObj]
+		,
+		{explSelfObj, Object, arg}
+		,
+		TestID -> "Non-inheritable: setterChildObj explicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterChildObj explicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterChildObj explicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member, explSelfObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterChildObj explicit self: \
+call member setterObj: explicit self explSelfObj"
+	];
+	Test[
+		setterObj[member, setterChildObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member, {setterObj, Object}
+		]
+		,
+		TestID -> "Non-inheritable: setterChildObj explicit self: \
+call member setterObj: explicit self setterChildObj"
+	];
+	
+	Test[
+		setterChildObj@member
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member, {setterObj, Object}
+		]
+		,
+		TestID -> "Non-inheritable: setterChildObj explicit self: \
+call member setterChildObj"
+	];
+	Test[
+		setterChildObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterChildObj explicit self: \
+call member setterChildObj: explicit self otherObj"
+	];
+	Test[
+		setterChildObj[member, explSelfObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterChildObj explicit self: \
+call member setterChildObj: explicit self explSelfObj"
+	];
+	Test[
+		setterChildObj[member, setterObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterChildObj explicit self: \
+call member setterChildObj: explicit self setterObj"
+	];
+	
+	Test[
+		explSelfObj@member
+		,
+		{explSelfObj, Object, arg}
+		,
+		TestID -> "Non-inheritable: setterChildObj explicit self: \
+call member explSelfObj"
+	];
+	Test[
+		explSelfObj[member, otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterChildObj explicit self: \
+call member explSelfObj: explicit self otherObj"
+	];
+	Test[
+		explSelfObj[member, setterObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member, {Object}]
+		,
+		TestID -> "Non-inheritable: setterChildObj explicit self: \
+call member explSelfObj: explicit self setterObj"
+	];
+	Test[
+		explSelfObj[member, setterChildObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member, {setterObj, Object}
+		]
+		,
+		TestID -> "Non-inheritable: setterChildObj explicit self: \
+call member explSelfObj: explicit self setterChildObj"
+	];
+]
+
+
+(* ::Subsection:: *)
+(*Inheritable-only*)
+
+
+(* ::Subsubsection:: *)
+(*setterObj implicit self*)
+
+
+Module[
+	{setterObj, setterChildObj, otherObj, member, setter, arg, arg2}
+	,
+	setUpObjects[setterObj, setterChildObj, otherObj];
+	setterObj@setter[x_] :=
+		WithOrdinaryObjectSet[$self,
+			$self[member[y_], self_] := {$self, self, Super[self], x, y}
+		];
+	
+	Test[
+		setterObj@setter[arg]
+		,
+		Null
+		,
+		TestID -> "Inheritable-only: setterObj implicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member[arg2]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setterObj implicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member[arg2], otherObj]
+		,
+		{$self, otherObj, Object, arg, arg2}
+		,
+		TestID -> "Inheritable-only: setterObj implicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member[arg2], setterChildObj]
+		,
+		{$self, setterChildObj, setterObj, arg, arg2}
+		,
+		TestID -> "Inheritable-only: setterObj implicit self: \
+call member setterObj: explicit self setterChildObj"
+	];
+	
+	Test[
+		setterChildObj@member[arg2]
+		,
+		{$self, setterChildObj, setterObj, arg, arg2}
+		,
+		TestID -> "Inheritable-only: setterObj implicit self: \
+call member setterChildObj"
+	];
+	Test[
+		setterChildObj[member[arg2], otherObj]
+		,
+		{$self, otherObj, Object, arg, arg2}
+		,
+		TestID -> "Inheritable-only: setterObj implicit self: \
+call member setterChildObj: explicit self otherObj"
+	];
+	Test[
+		setterChildObj[member[arg2], setterObj]
+		,
+		{$self, setterObj, Object, arg, arg2}
+		,
+		TestID -> "Inheritable-only: setterObj implicit self: \
+call member setterChildObj: explicit self setterObj"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*setterChildObj implicit self*)
+
+
+Module[
+	{setterObj, setterChildObj, otherObj, member, setter, arg, arg2}
+	,
+	setUpObjects[setterObj, setterChildObj, otherObj];
+	setterObj@setter[x_] :=
+		WithOrdinaryObjectSet[$self,
+			$self[member[y_], self_] := {$self, self, Super[self], x, y}
+		];
+	
+	Test[
+		setterChildObj@setter[arg]
+		,
+		Null
+		,
+		TestID -> "Inheritable-only: setterChildObj implicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member[arg2]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setterChildObj implicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member[arg2], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setterChildObj implicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member[arg2], setterChildObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member[arg2], {setterObj, Object}
+		]
+		,
+		TestID -> "Inheritable-only: setterChildObj implicit self: \
+call member setterObj: explicit self setterChildObj"
+	];
+	
+	Test[
+		setterChildObj@member[arg2]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member[arg2], {setterObj, Object}
+		]
+		,
+		TestID -> "Inheritable-only: setterChildObj implicit self: \
+call member setterChildObj"
+	];
+	Test[
+		setterChildObj[member[arg2], otherObj]
+		,
+		{$self, otherObj, Object, arg, arg2}
+		,
+		TestID -> "Inheritable-only: setterChildObj implicit self: \
+call member setterChildObj: explicit self otherObj"
+	];
+	Test[
+		setterChildObj[member[arg2], setterObj]
+		,
+		{$self, setterObj, Object, arg, arg2}
+		,
+		TestID -> "Inheritable-only: setterChildObj implicit self: \
+call member setterChildObj: explicit self setterObj"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*setterChildObj explicit self*)
+
+
+Module[
+	{
+		setterObj, setterChildObj, explSelfObj, otherObj,
+		member, setter, arg, arg2
+	}
+	,
+	setUpObjects[setterObj, setterChildObj, explSelfObj, otherObj];
+	setterObj@setter[x_] :=
+		WithOrdinaryObjectSet[$self,
+			$self[member[y_], self_] := {$self, self, Super[self], x, y}
+		];
+	
+	Test[
+		setterChildObj[setter[arg], explSelfObj]
+		,
+		Null
+		,
+		TestID -> "Inheritable-only: setterChildObj explicit self: call setter"
+	];
+	
+	Test[
+		setterObj@member[arg2]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setterChildObj explicit self: \
+call member setterObj"
+	];
+	Test[
+		setterObj[member[arg2], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setterChildObj explicit self: \
+call member setterObj: explicit self otherObj"
+	];
+	Test[
+		setterObj[member[arg2], explSelfObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setterChildObj explicit self: \
+call member setterObj: explicit self explSelfObj"
+	];
+	Test[
+		setterObj[member[arg2], setterChildObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member[arg2], {setterObj, Object}
+		]
+		,
+		TestID -> "Inheritable-only: setterChildObj explicit self: \
+call member setterObj: explicit self setterChildObj"
+	];
+	
+	Test[
+		setterChildObj@member[arg2]
+		,
+		$Failed
+		,
+		Message[Object::objectMember,
+			setterChildObj, member[arg2], {setterObj, Object}
+		]
+		,
+		TestID -> "Inheritable-only: setterChildObj explicit self: \
+call member setterChildObj"
+	];
+	Test[
+		setterChildObj[member[arg2], otherObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, otherObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setterChildObj explicit self: \
+call member setterChildObj: explicit self otherObj"
+	];
+	Test[
+		setterChildObj[member[arg2], explSelfObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setterChildObj explicit self: \
+call member setterChildObj: explicit self explSelfObj"
+	];
+	Test[
+		setterChildObj[member[arg2], setterObj]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, setterObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setterChildObj explicit self: \
+call member setterChildObj: explicit self setterObj"
+	];
+	
+	Test[
+		explSelfObj@member[arg2]
+		,
+		$Failed
+		,
+		Message[Object::objectMember, explSelfObj, member[arg2], {Object}]
+		,
+		TestID -> "Inheritable-only: setterChildObj explicit self: \
+call member explSelfObj"
+	];
+	Test[
+		explSelfObj[member[arg2], otherObj]
+		,
+		{$self, otherObj, Object, arg, arg2}
+		,
+		TestID -> "Inheritable-only: setterChildObj explicit self: \
+call member explSelfObj: explicit self otherObj"
+	];
+	Test[
+		explSelfObj[member[arg2], setterObj]
+		,
+		{$self, setterObj, Object, arg, arg2}
+		,
+		TestID -> "Inheritable-only: setterChildObj explicit self: \
+call member explSelfObj: explicit self setterObj"
+	];
+	Test[
+		explSelfObj[member[arg2], setterChildObj]
+		,
+		{$self, setterChildObj, setterObj, arg, arg2}
+		,
+		TestID -> "Inheritable-only: setterChildObj explicit self: \
+call member explSelfObj: explicit self setterChildObj"
+	];
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/ClasslessObjects/Tests/Integration/suite.mt
+++ b/ClasslessObjects/Tests/Integration/suite.mt
@@ -1,9 +1,15 @@
 TestSuite[{
-	"ObjectDeclaration.mt",
-	"ParentChanging.mt",
+	"ObjectDeclaration.mt"
+	,
+	"ParentChanging.mt"
+	,
 	"MembersNoInheritance.mt",
 	"MembersOneLevelInheritance.mt",
 	"MembersTwoLevelInheritance.mt",
-	"MembersExplicitSelf.mt",
+	"MembersExplicitSelf.mt"
+	,
+	"SettersNoInheritance.mt",
+	"SettersOneLevelInheritance.mt"
+	,
 	"ProtectedObjects.mt"
 }]

--- a/ClasslessObjects/Tests/Unit/bindMember.mt
+++ b/ClasslessObjects/Tests/Unit/bindMember.mt
@@ -42,8 +42,8 @@ Module[
 		DownValues[obj]
 		,
 		{
-			HoldPattern[obj[member]] :>  Block[{$self = obj}, value],
-			HoldPattern[obj[member, self_]] :> Block[{$self = self}, value]
+			HoldPattern[obj[member]] :> withBoundSelf[obj, value],
+			HoldPattern[obj[member, self_]] :> withBoundSelf[self, value]
 		}
 		,
 		TestID -> "Set member: object down values"
@@ -73,8 +73,8 @@ Module[
 		DownValues[obj]
 		,
 		{
-			HoldPattern[obj[member]] :>  Block[{$self = obj}, newValue],
-			HoldPattern[obj[member, self_]] :> Block[{$self = self}, newValue]
+			HoldPattern[obj[member]] :> withBoundSelf[obj, newValue],
+			HoldPattern[obj[member, self_]] :> withBoundSelf[self, newValue]
 		}
 		,
 		TestID -> "Reset member: object down values"
@@ -141,8 +141,8 @@ Module[
 		DownValues[obj]
 		,
 		{
-			HoldPattern[obj[member]] :>  Block[{$self = obj}, oldValue],
-			HoldPattern[obj[member, self_]] :> Block[{$self = self}, oldValue]
+			HoldPattern[obj[member]] :> withBoundSelf[obj, oldValue],
+			HoldPattern[obj[member, self_]] :> withBoundSelf[self, oldValue]
 		}
 		,
 		TestID -> "Reset member: object down values"

--- a/ClasslessObjects/Tests/Unit/suite.mt
+++ b/ClasslessObjects/Tests/Unit/suite.mt
@@ -5,6 +5,7 @@ TestSuite[{
 	"Object.mt",
 	"WithOrdinaryObjectSet.mt",
 	"SetSuper.mt",
+	"withBoundSelf.mt",
 	"setMember.mt",
 	"bindMember.mt",
 	"unsetMember.mt",

--- a/ClasslessObjects/Tests/Unit/withBoundSelf.mt
+++ b/ClasslessObjects/Tests/Unit/withBoundSelf.mt
@@ -1,0 +1,159 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage["ClasslessObjects`Tests`Unit`withBoundSelf`", {"MUnit`"}]
+
+
+Get["ClasslessObjects`"]
+
+
+AppendTo[$ContextPath, "ClasslessObjects`Private`"]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+(* ::Subsubsection:: *)
+(*Returned value*)
+
+
+Module[
+	{obj, body}
+	,
+	ObjectQ[obj] ^= True;
+	
+	Test[
+		withBoundSelf[obj, body]
+		,
+		body
+		,
+		TestID -> "Returned value"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*$self assignment*)
+
+
+Module[
+	{obj, tmp}
+	,
+	ObjectQ[obj] ^= True;
+	
+	Test[
+		withBoundSelf[obj, tmp = $self]
+		,
+		obj
+		,
+		TestID -> "$self assignment: withBoundSelf evaluation"
+	];
+	
+	Test[
+		tmp
+		,
+		obj
+		,
+		TestID -> "$self assignment: $self value"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*Set altering up value*)
+
+
+Module[
+	{obj, member, value, $log = {}}
+	,
+	ObjectQ[obj] ^= True;
+	obj /: (obj[lhs_] = rhs_) := AppendTo[$log, Hold[obj[lhs], rhs]];
+	
+	Test[
+		withBoundSelf[obj, $self@member = value]
+		,
+		{Hold[obj[member], value]}
+		,
+		TestID -> "Set altering up value: withBoundSelf evaluation"
+	];
+	
+	Test[
+		$log
+		,
+		{Hold[obj[member], value]}
+		,
+		TestID -> "Set altering up value: object Set log"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*SetDelayed altering up value*)
+
+
+Module[
+	{obj, member, value, $log = {}}
+	,
+	ObjectQ[obj] ^= True;
+	obj /: (obj[lhs_] := rhs_) := AppendTo[$log, Hold[obj[lhs], rhs]];
+	
+	Test[
+		withBoundSelf[obj, $self@member := value]
+		,
+		{Hold[obj[member], value]}
+		,
+		TestID -> "SetDelayed altering up value: withBoundSelf evaluation"
+	];
+	
+	Test[
+		$log
+		,
+		{Hold[obj[member], value]}
+		,
+		TestID -> "SetDelayed altering up value: object SetDelayed log"
+	];
+]
+
+
+(* ::Subsubsection:: *)
+(*Unset altering up value*)
+
+
+Module[
+	{obj, member, $log = {}}
+	,
+	ObjectQ[obj] ^= True;
+	obj /: (obj[lhs_] =.) := AppendTo[$log, Hold[obj[lhs]]];
+	
+	Test[
+		withBoundSelf[obj, $self@member =.]
+		,
+		{Hold[obj[member]]}
+		,
+		TestID -> "Set altering up value: withBoundSelf evaluation"
+	];
+	
+	Test[
+		$log
+		,
+		{Hold[obj[member]]}
+		,
+		TestID -> "Set altering up value: object Set log"
+	];
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/ClasslessObjects/Tests/suite.mt
+++ b/ClasslessObjects/Tests/suite.mt
@@ -5,6 +5,7 @@ TestSuite[{
 	"Unit/Object.mt",
 	"Unit/WithOrdinaryObjectSet.mt",
 	"Unit/SetSuper.mt",
+	"Unit/withBoundSelf.mt",
 	"Unit/setMember.mt",
 	"Unit/bindMember.mt",
 	"Unit/unsetMember.mt",

--- a/ClasslessObjects/Tests/suite.mt
+++ b/ClasslessObjects/Tests/suite.mt
@@ -16,5 +16,7 @@ TestSuite[{
 	"Integration/MembersOneLevelInheritance.mt",
 	"Integration/MembersTwoLevelInheritance.mt",
 	"Integration/MembersExplicitSelf.mt",
+	"Integration/SettersNoInheritance.mt",
+	"Integration/SettersOneLevelInheritance.mt",
 	"Integration/ProtectedObjects.mt"
 }]


### PR DESCRIPTION
Add set-altering up values to '$self' in every bound member call.

Fixes #3.
