### PR TITLE
Use optional arguments instead of duplicate member definitions

### DIFF
--- a/ClasslessObjects/ClasslessObjects.m
+++ b/ClasslessObjects/ClasslessObjects.m
@@ -303,10 +303,7 @@ SetSuper[obj_?ObjectQ, super_?ObjectQ] := (
 	
 	WithOrdinaryObjectSet[obj,
 		(* Delegate any undefinded member call to parent object. *)
-		(* For calls directly on this object. *)
-		obj[x_] := super[x, obj];
-		(* For calls on objects inheriting from this object. *)
-		obj[x_, self_] := super[x, self]
+		obj[x_, self_:obj] := super[x, self]
 	]
 )
 	

--- a/ClasslessObjects/Tests/Integration/ProtectedObjects.mt
+++ b/ClasslessObjects/Tests/Integration/ProtectedObjects.mt
@@ -54,7 +54,7 @@ Module[
 		,
 		value
 		,
-		Message[Set::write, obj, obj[member, _]]
+		Message[Set::write, obj, obj[member, HoldPattern[_]]]
 		,
 		TestID -> "Set: inheritable-only member"
 	]
@@ -72,7 +72,9 @@ Module[
 		,
 		value
 		,
-		Message[Set::write, obj, obj@member]
+		Message[Set::write,
+			obj, obj[member, HoldPattern[Optional][HoldPattern[_], obj]]
+		]
 		,
 		TestID -> "Set: inheritable member"
 	]
@@ -116,7 +118,7 @@ Module[
 		,
 		$Failed
 		,
-		Message[SetDelayed::write, obj, obj[member, _]]
+		Message[SetDelayed::write, obj, obj[member, HoldPattern[_]]]
 		,
 		TestID -> "SetDelayed: inheritable-only member"
 	]
@@ -134,7 +136,9 @@ Module[
 		,
 		$Failed
 		,
-		Message[SetDelayed::write, obj, obj@member]
+		Message[SetDelayed::write,
+			obj, obj[member, HoldPattern[Optional][HoldPattern[_], obj]]
+		]
 		,
 		TestID -> "SetDelayed: inheritable member"
 	]
@@ -178,7 +182,7 @@ Module[
 		,
 		$Failed
 		,
-		Message[Unset::write, obj, obj[member, _]]
+		Message[Unset::write, obj, obj[member, HoldPattern[_]]]
 		,
 		TestID -> "Unset: inheritable-only member"
 	]

--- a/ClasslessObjects/Tests/Unit/Utilities.m
+++ b/ClasslessObjects/Tests/Unit/Utilities.m
@@ -26,8 +26,8 @@ ClearAll[inheritanceDownValues]
 inheritanceDownValues::usage =
 "\
 inheritanceDownValues[child, parent] \
-returns list containing two down value rules that let child inherit members \
-from parent."
+returns list containing down value rule that let child inherit members from \
+parent."
 
 
 Unprotect[setAlteringUpValues]
@@ -74,15 +74,13 @@ declareMockObject[obj_, super_] := (
 
 
 inheritanceDownValues[child_, parent_] := {
-	HoldPattern[HoldPattern][
-		HoldPattern[child][HoldPattern[Pattern][x_, Blank[]]]
-	] :>
-		parent[x_, child]
-	,
 	HoldPattern[HoldPattern][HoldPattern[child][
-		HoldPattern[Pattern][x_, Blank[]],
-		HoldPattern[Pattern][self_, Blank[]]]
-	] :>
+		HoldPattern[Pattern][x_, HoldPattern[Blank][]],
+		HoldPattern[Optional][
+			HoldPattern[Pattern][self_, HoldPattern[Blank][]],
+			child
+		]
+	]] :>
 		parent[x_, self_]
 }
 

--- a/ClasslessObjects/Tests/Unit/bindMember.mt
+++ b/ClasslessObjects/Tests/Unit/bindMember.mt
@@ -41,10 +41,7 @@ Module[
 	Test[
 		DownValues[obj]
 		,
-		{
-			HoldPattern[obj[member]] :> withBoundSelf[obj, value],
-			HoldPattern[obj[member, self_]] :> withBoundSelf[self, value]
-		}
+		{HoldPattern[obj[member, self_:obj]] :> withBoundSelf[self, value]}
 		,
 		TestID -> "Set member: object down values"
 	];
@@ -72,10 +69,7 @@ Module[
 	Test[
 		DownValues[obj]
 		,
-		{
-			HoldPattern[obj[member]] :> withBoundSelf[obj, newValue],
-			HoldPattern[obj[member, self_]] :> withBoundSelf[self, newValue]
-		}
+		{HoldPattern[obj[member, self_:obj]] :> withBoundSelf[self, newValue]}
 		,
 		TestID -> "Reset member: object down values"
 	];
@@ -101,7 +95,9 @@ Module[
 		,
 		$Failed
 		,
-		Message[SetDelayed::write, obj, obj@member]
+		Message[SetDelayed::write,
+			obj, obj[member, HoldPattern[Optional][HoldPattern[_], obj]]
+		]
 		,
 		TestID -> "Set member: bindMember evaluation"
 	];
@@ -132,7 +128,9 @@ Module[
 		,
 		$Failed
 		,
-		Message[SetDelayed::write, obj, obj@member]
+		Message[SetDelayed::write,
+			obj, obj[member, HoldPattern[Optional][HoldPattern[_], obj]]
+		]
 		,
 		TestID -> "Reset member: bindMember evaluation"
 	];
@@ -140,10 +138,7 @@ Module[
 	Test[
 		DownValues[obj]
 		,
-		{
-			HoldPattern[obj[member]] :> withBoundSelf[obj, oldValue],
-			HoldPattern[obj[member, self_]] :> withBoundSelf[self, oldValue]
-		}
+		{HoldPattern[obj[member, self_:obj]] :> withBoundSelf[self, oldValue]}
 		,
 		TestID -> "Reset member: object down values"
 	];

--- a/ClasslessObjects/Tests/Unit/setMember.mt
+++ b/ClasslessObjects/Tests/Unit/setMember.mt
@@ -41,10 +41,7 @@ Module[
 	Test[
 		DownValues[obj]
 		,
-		{
-			HoldPattern[obj[member]] :> value,
-			HoldPattern[obj[member, _]] :> value
-		}
+		{HoldPattern[obj[member, _:obj]] :> value}
 		,
 		TestID -> "Set member: object down values"
 	];
@@ -72,10 +69,7 @@ Module[
 	Test[
 		DownValues[obj]
 		,
-		{
-			HoldPattern[obj[member]] :> newValue,
-			HoldPattern[obj[member, _]] :> newValue
-		}
+		{HoldPattern[obj[member, _:obj]] :> newValue}
 		,
 		TestID -> "Reset member: object down values"
 	];
@@ -101,7 +95,9 @@ Module[
 		,
 		value
 		,
-		Message[Set::write, obj, obj@member]
+		Message[Set::write,
+			obj, obj[member, HoldPattern[Optional][HoldPattern[_], obj]]
+		]
 		,
 		TestID -> "Protected: Set member: setMember evaluation"
 	];
@@ -132,7 +128,9 @@ Module[
 		,
 		newValue
 		,
-		Message[Set::write, obj, obj@member]
+		Message[Set::write,
+			obj, obj[member, HoldPattern[Optional][HoldPattern[_], obj]]
+		]
 		,
 		TestID -> "Protected: Reset member: setMember evaluation"
 	];
@@ -140,10 +138,7 @@ Module[
 	Test[
 		DownValues[obj]
 		,
-		{
-			HoldPattern[obj[member]] :> oldValue,
-			HoldPattern[obj[member, _]] :> oldValue
-		}
+		{HoldPattern[obj[member, _:obj]] :> oldValue}
 		,
 		TestID -> "Protected: Reset member: object down values"
 	];

--- a/ClasslessObjects/Tests/Unit/unsetMember.mt
+++ b/ClasslessObjects/Tests/Unit/unsetMember.mt
@@ -142,7 +142,7 @@ Module[
 	{obj, member, value}
 	,
 	ObjectQ[obj] ^= True;
-	obj[member, self_] := self + value;
+	obj[member, self_] := {value, self};
 	
 	Test[
 		unsetMember[obj, member]
@@ -170,8 +170,7 @@ Module[
 	{obj, member, value}
 	,
 	ObjectQ[obj] ^= True;
-	obj[member] = value;
-	obj[member, _] = value;
+	obj[member, _:obj] = value;
 	
 	Test[
 		unsetMember[obj, member]
@@ -199,8 +198,7 @@ Module[
 	{obj, member, value}
 	,
 	ObjectQ[obj] ^= True;
-	obj[member] := value;
-	obj[member, _] := value;
+	obj[member, self_:obj] := {value, self};
 	
 	Test[
 		unsetMember[obj, member]
@@ -361,7 +359,7 @@ Module[
 	{obj, member, value, downValues}
 	,
 	ObjectQ[obj] ^= True;
-	obj[member, self_] := self + value;
+	obj[member, self_] := {value, self};
 	Protect[obj];
 	downValues = DownValues[obj];
 	
@@ -395,8 +393,7 @@ Module[
 	{obj, member, value, downValues}
 	,
 	ObjectQ[obj] ^= True;
-	obj[member] = value;
-	obj[member, _] = value;
+	obj[member, _:obj] = value;
 	Protect[obj];
 	downValues = DownValues[obj];
 	
@@ -428,8 +425,7 @@ Module[
 	{obj, member, value, downValues}
 	,
 	ObjectQ[obj] ^= True;
-	obj[member] := value;
-	obj[member, _] := value;
+	obj[member, self_:obj] := {value, self};
 	Protect[obj];
 	downValues = DownValues[obj];
 	


### PR DESCRIPTION
Replace pairs of inheritable member definitions:

``` Mathematica
obj[lhs] ...
obj[lhs, self_] ...
```

with one definition with optional argument:

``` Mathematica
obj[lhs, self_:obj] ...
```
