### PR TITLE
Enhance WithOrdinaryObjectSet

### DIFF
--- a/ClasslessObjects/ClasslessObjects.m
+++ b/ClasslessObjects/ClasslessObjects.m
@@ -199,6 +199,10 @@ getInheritanceChain[obj_?ObjectQ, ances_:Object] /; ObjectQ[ances] :=
 
 Object::object = "Object expected at position `1` in `2`."
 
+Object::objects =
+"Object or non-empty list of objects expected at position `1` in `2`. \
+Argument contained following non-object(s): `3`."
+
 Object::nonObject = "Non-object expected at position `1` in `2`."
 
 Object::objectMember =

--- a/ClasslessObjects/Tests/Unit/Object.mt
+++ b/ClasslessObjects/Tests/Unit/Object.mt
@@ -112,6 +112,18 @@ Test[
 
 
 Test[
+	ToString @ StringForm[Object::objects,
+		HoldForm[2], HoldForm[f[arg1, {obj, nonObj}]], HoldForm[nonObj]
+	]
+	,
+	"Object or non-empty list of objects expected at position 2 in \
+f[arg1, {obj, nonObj}]. Argument contained following non-object(s): nonObj."
+	,
+	TestID -> "objects"
+]
+
+
+Test[
 	ToString @
 		StringForm[Object::nonObject, HoldForm[2], HoldForm[f[arg1, arg2]]]
 	,

--- a/ClasslessObjects/Tests/Unit/WithOrdinaryObjectSet.mt
+++ b/ClasslessObjects/Tests/Unit/WithOrdinaryObjectSet.mt
@@ -545,6 +545,195 @@ Module[
 ]
 
 
+(* ::Subsubsection:: *)
+(*Flow Control*)
+
+
+Module[
+	{
+		obj, evaluationResult, aborted,
+		oldUpValues, oldAttributes,
+		accessor, value
+	}
+	,
+	declareMockObjectWithAlteredSetUpValues[obj];
+	
+	oldUpValues = UpValues[obj];
+	oldAttributes = Attributes[obj];
+	
+	Test[
+		CheckAbort[
+			WithOrdinaryObjectSet[obj,
+				accessor[obj] ^= value;
+				
+				Abort[];
+				
+				evaluationResult
+			]
+			,
+			aborted
+		]
+		,
+		aborted
+		,
+		TestID -> "flow control: abort: evaluation"
+	];
+	
+	Test[
+		UpValues[obj]
+		,
+		Prepend[oldUpValues, HoldPattern[accessor[obj]] :> value]
+		,
+		TestID -> "flow control: abort: after: UpValues"
+	];
+	Test[
+		Attributes[obj]
+		,
+		oldAttributes
+		,
+		TestID -> "flow control: abort: after: Attributes"
+	];
+]
+
+
+Module[
+	{
+		obj, evaluationResult, thrownValue,
+		oldUpValues, oldAttributes,
+		accessor, value
+	}
+	,
+	declareMockObjectWithAlteredSetUpValues[obj];
+	
+	oldUpValues = UpValues[obj];
+	oldAttributes = Attributes[obj];
+	
+	Test[
+		Catch[
+			WithOrdinaryObjectSet[obj,
+				accessor[obj] ^= value;
+				
+				Throw[thrownValue];
+				
+				evaluationResult
+			]
+		]
+		,
+		thrownValue
+		,
+		TestID -> "flow control: throw no tag: evaluation"
+	];
+	
+	Test[
+		UpValues[obj]
+		,
+		Prepend[oldUpValues, HoldPattern[accessor[obj]] :> value]
+		,
+		TestID -> "flow control: throw no tag: after: UpValues"
+	];
+	Test[
+		Attributes[obj]
+		,
+		oldAttributes
+		,
+		TestID -> "flow control: throw no tag: after: Attributes"
+	];
+]
+
+
+Module[
+	{
+		obj, evaluationResult, thrownValue, throwTag,
+		oldUpValues, oldAttributes,
+		accessor, value
+	}
+	,
+	declareMockObjectWithAlteredSetUpValues[obj];
+	
+	oldUpValues = UpValues[obj];
+	oldAttributes = Attributes[obj];
+	
+	Test[
+		Catch[
+			WithOrdinaryObjectSet[obj,
+				accessor[obj] ^= value;
+				
+				Throw[thrownValue, throwTag];
+				
+				evaluationResult
+			]
+			,
+			throwTag
+		]
+		,
+		thrownValue
+		,
+		TestID -> "flow control: throw with tag: evaluation"
+	];
+	
+	Test[
+		UpValues[obj]
+		,
+		Prepend[oldUpValues, HoldPattern[accessor[obj]] :> value]
+		,
+		TestID -> "flow control: throw with tag: after: UpValues"
+	];
+	Test[
+		Attributes[obj]
+		,
+		oldAttributes
+		,
+		TestID -> "flow control: throw with tag: after: Attributes"
+	];
+]
+
+
+Module[
+	{
+		obj, evaluationResult,
+		label, lebeledReturnValue,
+		oldUpValues, oldAttributes,
+		accessor, value
+	}
+	,
+	declareMockObjectWithAlteredSetUpValues[obj];
+	
+	oldUpValues = UpValues[obj];
+	oldAttributes = Attributes[obj];
+	
+	Test[
+		WithOrdinaryObjectSet[obj,
+			accessor[obj] ^= value;
+			
+			Goto[label];
+			
+			evaluationResult
+		];
+		Label[label];
+		lebeledReturnValue
+		,
+		lebeledReturnValue
+		,
+		TestID -> "flow control: goto: evaluation"
+	];
+	
+	Test[
+		UpValues[obj]
+		,
+		Prepend[oldUpValues, HoldPattern[accessor[obj]] :> value]
+		,
+		TestID -> "flow control: goto: after: UpValues"
+	];
+	Test[
+		Attributes[obj]
+		,
+		oldAttributes
+		,
+		TestID -> "flow control: goto: after: Attributes"
+	];
+]
+
+
 (* ::Section:: *)
 (*TearDown*)
 


### PR DESCRIPTION
- Added possibility of passing list of objects to `WithOrdinaryObjectSet`.
- Fixed #7. `UpValues` set inside `WithOrdinaryObjectSet` are no longer deleted.
- Fixed #8. Added flow control safeguards for expressions passed as body of `WithOrdinaryObjectSet`.
