### PR TITLE
Enhance wrong argument patterns warnings

### DIFF
--- a/ClasslessObjects/ClasslessObjects.m
+++ b/ClasslessObjects/ClasslessObjects.m
@@ -151,7 +151,7 @@ unsets ordinary: obj[member] and inheritable: obj[member, self_] definitions."
 (*fixArgumentsNumber*)
 
 
-fixArgumentsNumber[sym_Symbol, argNo_Integer] :=
+fixArgumentsNumber[sym_Symbol, argNo_Integer] := (
 	If[argNo === 1,
 		sym[args___] := "nothing" /;
 			With[
@@ -179,7 +179,10 @@ fixArgumentsNumber[sym_Symbol, argNo_Integer] :=
 						]
 				]
 			];
-	]
+	];
+	
+	SyntaxInformation[sym] = {"ArgumentsPattern" -> ConstantArray[_, argNo]};
+)
 
 
 (* ::Subsection:: *)
@@ -522,6 +525,9 @@ DeclareObject[args___ /; !MatchQ[Length[{args}], 1 | 2]] := "nothing" /;
 		HoldForm[1],
 		HoldForm[2]
 	]
+
+
+SyntaxInformation[DeclareObject] = {"ArgumentsPattern" -> {_, _.}};
 
 
 End[]

--- a/ClasslessObjects/ClasslessObjects.m
+++ b/ClasslessObjects/ClasslessObjects.m
@@ -148,6 +148,19 @@ unsets ordinary: obj[member] and inheritable: obj[member, self_] definitions."
 
 
 (* ::Subsection:: *)
+(*General messages*)
+
+
+general::object = "Object expected at position `1` in `2`."
+
+general::objects =
+"Object or non-empty list of objects expected at position `1` in `2`. \
+Argument contained following non-object(s): `3`."
+
+general::nonObject = "Non-object expected at position `1` in `2`."
+
+
+(* ::Subsection:: *)
 (*fixArgumentsNumber*)
 
 
@@ -198,10 +211,13 @@ fixArgumentsNumber[ObjectQ, 1]
 (*Super*)
 
 
+Super::object = general::object
+
+
 Super[_?ObjectQ] = Object
 
 Super[arg_ /; !ObjectQ[arg]] := "nothing" /;
-	Message[Object::object, HoldForm[1], HoldForm[Super[arg]]]
+	Message[Super::object, HoldForm[1], HoldForm[Super[arg]]]
 
 fixArgumentsNumber[Super, 1]
 
@@ -221,14 +237,6 @@ getInheritanceChain[obj_?ObjectQ, ances_:Object] /; ObjectQ[ances] :=
 (* ::Subsection:: *)
 (*Object*)
 
-
-Object::object = "Object expected at position `1` in `2`."
-
-Object::objects =
-"Object or non-empty list of objects expected at position `1` in `2`. \
-Argument contained following non-object(s): `3`."
-
-Object::nonObject = "Non-object expected at position `1` in `2`."
 
 Object::objectMember =
 "The call `1`@`2` didn't match any of defined member patterns in `1` nor in \
@@ -257,6 +265,9 @@ ObjectQ[Object] ^= True
 
 (* ::Subsection:: *)
 (*WithOrdinaryObjectSet*)
+
+
+WithOrdinaryObjectSet::objects = general::objects
 
 
 SetAttributes[WithOrdinaryObjectSet, HoldRest]
@@ -319,7 +330,7 @@ WithOrdinaryObjectSet[objs:{__?ObjectQ}, body_] :=
 	
 WithOrdinaryObjectSet[arg1:{__} /; MemberQ[arg1, _?(!ObjectQ[#]&)], arg2_] :=
 	"nothing" /;
-		Message[Object::objects,
+		Message[WithOrdinaryObjectSet::objects,
 			HoldForm[1],
 			HoldForm[WithOrdinaryObjectSet[arg1, arg2]],
 			HoldForm[Evaluate[DeleteCases[arg1, _?ObjectQ]]]
@@ -327,7 +338,7 @@ WithOrdinaryObjectSet[arg1:{__} /; MemberQ[arg1, _?(!ObjectQ[#]&)], arg2_] :=
 	
 WithOrdinaryObjectSet[arg1:Except[{__}] /; !ObjectQ[arg1], arg2_] :=
 	"nothing" /;
-		Message[Object::objects,
+		Message[WithOrdinaryObjectSet::objects,
 			HoldForm[1],
 			HoldForm[WithOrdinaryObjectSet[arg1, arg2]],
 			HoldForm[arg1]
@@ -339,6 +350,8 @@ fixArgumentsNumber[WithOrdinaryObjectSet, 2]
 (* ::Subsection:: *)
 (*SetSuper*)
 
+
+SetSuper::object = general::object
 
 SetSuper::cyclic =
 "Object `1` can't inherit from object `2`, since it would lead to \
@@ -374,10 +387,10 @@ SetSuper[obj_?ObjectQ, super_?ObjectQ] := (
 )
 	
 SetSuper[arg1_ /; !ObjectQ[arg1], arg2_] := "nothing" /;
-	Message[Object::object, HoldForm[1], HoldForm[SetSuper[arg1, arg2]]]
+	Message[SetSuper::object, HoldForm[1], HoldForm[SetSuper[arg1, arg2]]]
 
 SetSuper[arg1_, arg2_ /; !ObjectQ[arg2]] := "nothing" /;
-	Message[Object::object, HoldForm[2], HoldForm[SetSuper[arg1, arg2]]]
+	Message[SetSuper::object, HoldForm[2], HoldForm[SetSuper[arg1, arg2]]]
 
 fixArgumentsNumber[SetSuper, 2]
 
@@ -486,6 +499,11 @@ unsetMember[obj_?ObjectQ, lhs_] :=
 (*DeclareObject*)
 
 
+DeclareObject::object = general::object
+
+DeclareObject::nonObject = general::nonObject
+
+
 (*
 	Using ObjectQ[super] condition because MMA 8 chokes on
 	super:_?ObjectQ:Object
@@ -511,12 +529,12 @@ DeclareObject[arg1:Except[_Symbol], Repeated[_, {0, 1}]] := "nothing" /;
 	Message[DeclareObject::sym, HoldForm[arg1], HoldForm[1]]
 
 DeclareObject[arg1_?ObjectQ, rest:Repeated[_, {0, 1}]] := "nothing" /;
-	Message[Object::nonObject,
+	Message[DeclareObject::nonObject,
 		HoldForm[1], HoldForm[DeclareObject[arg1, rest]]
 	]
 
 DeclareObject[arg1_, arg2_ /; !ObjectQ[arg2]] := "nothing" /;
-	Message[Object::object, HoldForm[2], HoldForm[DeclareObject[arg1, arg2]]]
+	Message[DeclareObject::object, HoldForm[2], HoldForm[DeclareObject[arg1, arg2]]]
 
 DeclareObject[args___ /; !MatchQ[Length[{args}], 1 | 2]] := "nothing" /;
 	Message[DeclareObject::argt,

--- a/ClasslessObjects/ClasslessObjects.m
+++ b/ClasslessObjects/ClasslessObjects.m
@@ -152,14 +152,32 @@ unsets ordinary: obj[member] and inheritable: obj[member, self_] definitions."
 
 
 fixArgumentsNumber[sym_Symbol, argNo_Integer] :=
-	With[
-		{msgName = If[argNo === 1, sym::argx, sym::argrx]}
-		,
-		sym[args___ /; Length[{args}] != argNo] := "nothing" /;
-			Message[msgName,
-				HoldForm[sym],
-				HoldForm[Evaluate @ Length[{args}]],
-				HoldForm[argNo]
+	If[argNo === 1,
+		sym[args___] := "nothing" /;
+			With[
+				{givenArgsNo = Length[{args}]}
+				,
+				If[givenArgsNo =!= 1,
+					Message[sym::argx, HoldForm[sym], HoldForm[givenArgsNo]]
+				]
+			];
+	(* else *),
+		sym[args___] := "nothing" /;
+			With[
+				{givenArgsNo = Length[{args}]}
+				,
+				Switch[givenArgsNo,
+					argNo,
+						False,
+					1,
+						Message[sym::argr, HoldForm[sym], HoldForm[argNo]],
+					_,
+						Message[sym::argrx,
+							HoldForm[sym],
+							HoldForm[givenArgsNo],
+							HoldForm[argNo]
+						]
+				]
 			];
 	]
 

--- a/ClasslessObjects/Tests/Unit/DeclareObject.mt
+++ b/ClasslessObjects/Tests/Unit/DeclareObject.mt
@@ -60,7 +60,7 @@ Module[
 		,
 		HoldPattern @ DeclareObject[mockObj1]
 		,
-		Message[Object::nonObject, 1, DeclareObject[mockObj1]]
+		Message[DeclareObject::nonObject, 1, DeclareObject[mockObj1]]
 		,
 		TestID -> "1 arg: object: DeclareObject evaluation"
 	];
@@ -91,7 +91,9 @@ Module[
 		,
 		{
 			Message[DeclareObject::sym, "non-symbol", 1],
-			Message[Object::object, 2, DeclareObject["non-symbol", nonObject2]]
+			Message[DeclareObject::object,
+				2, DeclareObject["non-symbol", nonObject2]
+			]
 		}
 		,
 		TestID -> "2 args: non-symbol, non-object: DeclareObject evaluation"
@@ -123,8 +125,12 @@ Module[
 		HoldPattern @ DeclareObject[mockObj1, nonObject2]
 		,
 		{
-			Message[Object::nonObject, 1, DeclareObject[mockObj1, nonObject2]],
-			Message[Object::object, 2, DeclareObject[mockObj1, nonObject2]]
+			Message[DeclareObject::nonObject,
+				1, DeclareObject[mockObj1, nonObject2]
+			],
+			Message[DeclareObject::object,
+				2, DeclareObject[mockObj1, nonObject2]
+			]
 		}
 		,
 		TestID -> "2 args: object, non-object: DeclareObject evaluation"
@@ -189,7 +195,7 @@ Module[
 		,
 		HoldPattern @ DeclareObject[mockObj1, mockObj2]
 		,
-		Message[Object::nonObject, 1, DeclareObject[mockObj1, mockObj2]]
+		Message[DeclareObject::nonObject, 1, DeclareObject[mockObj1, mockObj2]]
 		,
 		TestID -> "2 args: object, object: DeclareObject evaluation"
 	];
@@ -225,7 +231,9 @@ Module[
 		,
 		HoldPattern @ DeclareObject[nonObject1, nonObject2]
 		,
-		Message[Object::object, 2, DeclareObject[nonObject1, nonObject2]]
+		Message[DeclareObject::object,
+			2, DeclareObject[nonObject1, nonObject2]
+		]
 		,
 		TestID ->
 			"2 args: non-object symbol, non-object: DeclareObject evaluation"

--- a/ClasslessObjects/Tests/Unit/Object.mt
+++ b/ClasslessObjects/Tests/Unit/Object.mt
@@ -103,37 +103,6 @@ Test[
 
 
 Test[
-	ToString @ StringForm[Object::object, HoldForm[2], HoldForm[f[arg1, arg2]]]
-	,
-	"Object expected at position 2 in f[arg1, arg2]."
-	,
-	TestID -> "object"
-]
-
-
-Test[
-	ToString @ StringForm[Object::objects,
-		HoldForm[2], HoldForm[f[arg1, {obj, nonObj}]], HoldForm[nonObj]
-	]
-	,
-	"Object or non-empty list of objects expected at position 2 in \
-f[arg1, {obj, nonObj}]. Argument contained following non-object(s): nonObj."
-	,
-	TestID -> "objects"
-]
-
-
-Test[
-	ToString @
-		StringForm[Object::nonObject, HoldForm[2], HoldForm[f[arg1, arg2]]]
-	,
-	"Non-object expected at position 2 in f[arg1, arg2]."
-	,
-	TestID -> "nonObject"
-]
-
-
-Test[
 	ToString @ StringForm[Object::objectMember,
 		HoldForm[child],
 		HoldForm[f[arg1, arg2]],

--- a/ClasslessObjects/Tests/Unit/Object.mt
+++ b/ClasslessObjects/Tests/Unit/Object.mt
@@ -38,7 +38,7 @@ TestMatch[
 	,
 	HoldPattern @ Object[obj1]
 	,
-	Message[Object::argrx, Object, 1, 2]
+	Message[Object::argr, Object, 2]
 	,
 	TestID -> "1 arg"
 ]

--- a/ClasslessObjects/Tests/Unit/ObjectQ.mt
+++ b/ClasslessObjects/Tests/Unit/ObjectQ.mt
@@ -24,7 +24,7 @@ TestMatch[
 	,
 	HoldPattern @ ObjectQ[]
 	,
-	Message[ObjectQ::argx, ObjectQ, 0, 1]
+	Message[ObjectQ::argx, ObjectQ, 0]
 	,
 	TestID -> "no args"
 ]
@@ -35,7 +35,7 @@ TestMatch[
 	,
 	HoldPattern @ ObjectQ[sym1, sym2]
 	,
-	Message[ObjectQ::argx, ObjectQ, 2, 1]
+	Message[ObjectQ::argx, ObjectQ, 2]
 	,
 	TestID -> "2 args"
 ]

--- a/ClasslessObjects/Tests/Unit/SetSuper.mt
+++ b/ClasslessObjects/Tests/Unit/SetSuper.mt
@@ -49,7 +49,7 @@ Module[
 		,
 		HoldPattern @ SetSuper[arg1]
 		,
-		Message[SetSuper::argrx, SetSuper, 1, 2]
+		Message[SetSuper::argr, SetSuper, 2]
 		,
 		TestID -> "1 arg: SetSuper evaluation"
 	];

--- a/ClasslessObjects/Tests/Unit/SetSuper.mt
+++ b/ClasslessObjects/Tests/Unit/SetSuper.mt
@@ -80,8 +80,8 @@ Module[
 		HoldPattern @ SetSuper[arg1, arg2]
 		,
 		{
-			Message[Object::object, 1, SetSuper[arg1, arg2]],
-			Message[Object::object, 2, SetSuper[arg1, arg2]]
+			Message[SetSuper::object, 1, SetSuper[arg1, arg2]],
+			Message[SetSuper::object, 2, SetSuper[arg1, arg2]]
 		}
 		,
 		TestID -> "2 args: both non-objects: SetSuper evaluation"
@@ -117,7 +117,7 @@ Module[
 		,
 		HoldPattern @ SetSuper[arg1, arg2]
 		,
-		Message[Object::object, 1, SetSuper[arg1, arg2]]
+		Message[SetSuper::object, 1, SetSuper[arg1, arg2]]
 		,
 		TestID -> "2 args: non-object, object: SetSuper evaluation"
 	];
@@ -152,7 +152,7 @@ Module[
 		,
 		HoldPattern @ SetSuper[arg1, arg2]
 		,
-		Message[Object::object, 2, SetSuper[arg1, arg2]]
+		Message[SetSuper::object, 2, SetSuper[arg1, arg2]]
 		,
 		TestID -> "2 args: object, non-object: SetSuper evaluation"
 	];

--- a/ClasslessObjects/Tests/Unit/Super.mt
+++ b/ClasslessObjects/Tests/Unit/Super.mt
@@ -24,7 +24,7 @@ TestMatch[
 	,
 	HoldPattern @ Super[]
 	,
-	Message[Super::argx, Super, 0, 1]
+	Message[Super::argx, Super, 0]
 	,
 	TestID -> "no args"
 ]
@@ -46,7 +46,7 @@ TestMatch[
 	,
 	HoldPattern @ Super[sym1, sym2]
 	,
-	Message[Super::argx, Super, 2, 1]
+	Message[Super::argx, Super, 2]
 	,
 	TestID -> "2 args"
 ]

--- a/ClasslessObjects/Tests/Unit/Super.mt
+++ b/ClasslessObjects/Tests/Unit/Super.mt
@@ -35,7 +35,7 @@ TestMatch[
 	,
 	HoldPattern @ Super[sym]
 	,
-	Message[Object::object, 1, Super[sym]]
+	Message[Super::object, 1, Super[sym]]
 	,
 	TestID -> "1 arg: non-object"
 ]

--- a/ClasslessObjects/Tests/Unit/WithOrdinaryObjectSet.mt
+++ b/ClasslessObjects/Tests/Unit/WithOrdinaryObjectSet.mt
@@ -104,7 +104,9 @@ Module[
 		,
 		HoldPattern @ WithOrdinaryObjectSet[arg1, arg2]
 		,
-		Message[Object::objects, 1, WithOrdinaryObjectSet[arg1, arg2], arg1]
+		Message[WithOrdinaryObjectSet::objects,
+			1, WithOrdinaryObjectSet[arg1, arg2], arg1
+		]
 		,
 		TestID -> "2 args: first non-object: evaluation"
 	]
@@ -118,7 +120,9 @@ Module[
 		,
 		HoldPattern @ WithOrdinaryObjectSet[{}, arg2]
 		,
-		Message[Object::objects, 1, WithOrdinaryObjectSet[{}, arg2], {}]
+		Message[WithOrdinaryObjectSet::objects,
+			1, WithOrdinaryObjectSet[{}, arg2], {}
+		]
 		,
 		TestID -> "2 args: first empty list: evaluation"
 	]
@@ -132,7 +136,7 @@ Module[
 		,
 		HoldPattern @ WithOrdinaryObjectSet[{nonObj1}, arg2]
 		,
-		Message[Object::objects,
+		Message[WithOrdinaryObjectSet::objects,
 			1, WithOrdinaryObjectSet[{nonObj1}, arg2], {nonObj1}
 		]
 		,
@@ -148,7 +152,7 @@ Module[
 		,
 		HoldPattern @ WithOrdinaryObjectSet[{nonObj1, nonObj2}, arg2]
 		,
-		Message[Object::objects,
+		Message[WithOrdinaryObjectSet::objects,
 			1,
 			WithOrdinaryObjectSet[{nonObj1, nonObj2}, arg2],
 			{nonObj1, nonObj2}
@@ -171,7 +175,7 @@ Module[
 		,
 		HoldPattern @ WithOrdinaryObjectSet[{obj, nonObj2}, arg2]
 		,
-		Message[Object::objects,
+		Message[WithOrdinaryObjectSet::objects,
 			1, WithOrdinaryObjectSet[{obj, nonObj2}, arg2], {nonObj2}
 		]
 		,

--- a/ClasslessObjects/Tests/Unit/WithOrdinaryObjectSet.mt
+++ b/ClasslessObjects/Tests/Unit/WithOrdinaryObjectSet.mt
@@ -74,7 +74,7 @@ Module[
 		,
 		HoldPattern @ WithOrdinaryObjectSet[obj]
 		,
-		Message[WithOrdinaryObjectSet::argrx, WithOrdinaryObjectSet, 1, 2]
+		Message[WithOrdinaryObjectSet::argr, WithOrdinaryObjectSet, 2]
 		,
 		TestID -> "1 arg: evaluation"
 	];

--- a/ClasslessObjects/Tests/Unit/generalMessages.mt
+++ b/ClasslessObjects/Tests/Unit/generalMessages.mt
@@ -1,0 +1,60 @@
+(* Mathematica Test File *)
+
+(* ::Section:: *)
+(*SetUp*)
+
+
+BeginPackage["ClasslessObjects`Tests`Unit`generalMessages`", {"MUnit`"}]
+
+
+Get["ClasslessObjects`"]
+
+
+AppendTo[$ContextPath, "ClasslessObjects`Private`"]
+
+
+(* ::Section:: *)
+(*Tests*)
+
+
+Test[
+	ToString @ StringForm[general::object, HoldForm[2], HoldForm[f[arg1, arg2]]]
+	,
+	"Object expected at position 2 in f[arg1, arg2]."
+	,
+	TestID -> "object"
+]
+
+
+Test[
+	ToString @ StringForm[general::objects,
+		HoldForm[2], HoldForm[f[arg1, {obj, nonObj}]], HoldForm[nonObj]
+	]
+	,
+	"Object or non-empty list of objects expected at position 2 in \
+f[arg1, {obj, nonObj}]. Argument contained following non-object(s): nonObj."
+	,
+	TestID -> "objects"
+]
+
+
+Test[
+	ToString @
+		StringForm[general::nonObject, HoldForm[2], HoldForm[f[arg1, arg2]]]
+	,
+	"Non-object expected at position 2 in f[arg1, arg2]."
+	,
+	TestID -> "nonObject"
+]
+
+
+(* ::Section:: *)
+(*TearDown*)
+
+
+Unprotect["`*"]
+Quiet[Remove["`*"], {Remove::rmnsm}]
+
+
+EndPackage[]
+$ContextPath = Rest[$ContextPath]

--- a/ClasslessObjects/Tests/Unit/suite.mt
+++ b/ClasslessObjects/Tests/Unit/suite.mt
@@ -1,4 +1,5 @@
 TestSuite[{
+	"generalMessages.mt",
 	"ObjectQ.mt",
 	"Super.mt",
 	"getInheritanceChain.mt",

--- a/ClasslessObjects/Tests/suite.mt
+++ b/ClasslessObjects/Tests/suite.mt
@@ -1,4 +1,5 @@
 TestSuite[{
+	"Unit/generalMessages.mt",
 	"Unit/ObjectQ.mt",
 	"Unit/Super.mt",
 	"Unit/getInheritanceChain.mt",


### PR DESCRIPTION
- Use `argr` message when incorrect arguments number is 1.
- Don't pass third argument to `argx` message.
- Add `SyntaxInformation`.
- Use messages attached to particular symbols not to `Object` symbol.
